### PR TITLE
Support optional question tag for multiple choice questions

### DIFF
--- a/examples/check-uk-visa/questions/planning_to_leave_airport.txt
+++ b/examples/check-uk-visa/questions/planning_to_leave_airport.txt
@@ -4,6 +4,7 @@ You might pass through UK Border Control even if you don't leave the airport -
 eg your bags aren't checked through and you need to collect them before transferring
 to your outbound flight.
 
+[choice: planning_to_leave_airport]
 * yes => "Yes"
 * no => "No"
 

--- a/examples/check-uk-visa/questions/purpose_of_visit.txt
+++ b/examples/check-uk-visa/questions/purpose_of_visit.txt
@@ -1,5 +1,6 @@
 # What are you coming to the UK to do?
 
+[choice: purpose_of_visit]
 * study: Study
 * work: Work or business
 * tourism: Tourism, including visiting friends or family

--- a/examples/check-uk-visa/questions/staying_for_how_long.txt
+++ b/examples/check-uk-visa/questions/staying_for_how_long.txt
@@ -1,5 +1,6 @@
 # How long are you planning to %{activity_whilst_staying} in the UK for?"
 
+[choice: staying_for_how_long]
 * six_months_or_less: "6 months or less"
 * longer_than_six_months: "longer than 6 months"
 

--- a/examples/check-uk-visa/questions/what_passport_do_you_have.txt
+++ b/examples/check-uk-visa/questions/what_passport_do_you_have.txt
@@ -1,6 +1,6 @@
 # What passport do you have?
 
-[country v]
+[country: what_passport_do_you_have]
 
 -------
 

--- a/examples/student-finance-forms/questions/continuing_student.txt
+++ b/examples/student-finance-forms/questions/continuing_student.txt
@@ -1,5 +1,6 @@
 # Are you a continuing student?
 
+[choice: continuing_student]
 * continuing-student: Yes
 * new-student: No
 

--- a/examples/student-finance-forms/questions/form_needed_for_1.txt
+++ b/examples/student-finance-forms/questions/form_needed_for_1.txt
@@ -1,5 +1,6 @@
 # What do you need the form for?
 
+[choice: form_needed_for_1]
 * apply-loans-grants: Apply for student loans and grants
 * proof-identity: Send proof of identity
 * income-details: Send parent or partner’s income detail - eg PFF2 or CYI

--- a/examples/student-finance-forms/questions/form_needed_for_2.txt
+++ b/examples/student-finance-forms/questions/form_needed_for_2.txt
@@ -1,5 +1,6 @@
 # What do you need the form for?
 
+[choice: form_needed_for_2]
 * apply-loans-grants: Apply for student loans and grants
 * proof-identity: Send proof of identity
 * apply-dsa: Apply for Disabled Students’ Allowances

--- a/examples/student-finance-forms/questions/pt_course_start.txt
+++ b/examples/student-finance-forms/questions/pt_course_start.txt
@@ -1,5 +1,6 @@
 # Did your part-time course start before 1 September 2012?
 
+[choice: pt_course_start]
 * course-start-before-01092012: Yes
 * course-start-after-01092012: No
 

--- a/examples/student-finance-forms/questions/type_of_student.txt
+++ b/examples/student-finance-forms/questions/type_of_student.txt
@@ -1,5 +1,6 @@
 # What type of a student are you?
 
+[choice: type_of_student]
 * uk-full-time: English student - full-time
 * uk-part-time: English student - part-time
 * eu-full-time: EU student - full-time

--- a/examples/student-finance-forms/questions/what_year.txt
+++ b/examples/student-finance-forms/questions/what_year.txt
@@ -1,5 +1,6 @@
 # What academic year do you want funding for?
 
+[choice: what_year]
 * year-1314: 2013 to 2014
 * year-1415: 2014 to 2015
 

--- a/lib/smartdown/parser/element/multiple_choice_question.rb
+++ b/lib/smartdown/parser/element/multiple_choice_question.rb
@@ -4,6 +4,16 @@ module Smartdown
   module Parser
     module Element
       class MultipleChoiceQuestion < Base
+        rule(:multiple_choice_question_tag) {
+          str("[choice:") >>
+            optional_space >>
+            question_identifier.as(:identifier) >>
+            optional_space >>
+            str("]") >>
+            optional_space >>
+            line_ending
+        }
+
         rule(:option_definition_line) {
           bullet >>
             optional_space >>
@@ -15,7 +25,10 @@ module Smartdown
         }
 
         rule(:multiple_choice_question) {
-          (option_definition_line >> line_ending).repeat(1).as(:multiple_choice)
+          (
+            multiple_choice_question_tag.maybe >>
+            (option_definition_line >> line_ending).repeat(1).as(:options)
+          ).as(:multiple_choice)
         }
         root(:multiple_choice_question)
       end

--- a/lib/smartdown/parser/element/multiple_choice_question.rb
+++ b/lib/smartdown/parser/element/multiple_choice_question.rb
@@ -26,7 +26,7 @@ module Smartdown
 
         rule(:multiple_choice_question) {
           (
-            multiple_choice_question_tag.maybe >>
+            multiple_choice_question_tag >>
             (option_definition_line >> line_ending).repeat(1).as(:options)
           ).as(:multiple_choice)
         }

--- a/lib/smartdown/parser/node_transform.rb
+++ b/lib/smartdown/parser/node_transform.rb
@@ -50,9 +50,15 @@ module Smartdown
         [value.to_s, label.to_s]
       }
 
-      rule(:multiple_choice => subtree(:choices)) {
+      rule(:multiple_choice => {options: subtree(:choices)}) {
         Smartdown::Model::Element::MultipleChoice.new(
           node_name, Hash[choices]
+        )
+      }
+
+      rule(:multiple_choice => {identifier: simple(:identifier), options: subtree(:choices)}) {
+        Smartdown::Model::Element::MultipleChoice.new(
+          identifier, Hash[choices]
         )
       }
 

--- a/lib/smartdown/parser/node_transform.rb
+++ b/lib/smartdown/parser/node_transform.rb
@@ -50,12 +50,6 @@ module Smartdown
         [value.to_s, label.to_s]
       }
 
-      rule(:multiple_choice => {options: subtree(:choices)}) {
-        Smartdown::Model::Element::MultipleChoice.new(
-          node_name, Hash[choices]
-        )
-      }
-
       rule(:multiple_choice => {identifier: simple(:identifier), options: subtree(:choices)}) {
         Smartdown::Model::Element::MultipleChoice.new(
           identifier, Hash[choices]

--- a/spec/fixtures/acceptance/one-question/questions/q1.txt
+++ b/spec/fixtures/acceptance/one-question/questions/q1.txt
@@ -5,5 +5,6 @@ Body text line 1.
 Body text
 para 2.
 
+[choice: q1]
 * yes: Yes
 * no: No

--- a/spec/fixtures/acceptance/question-and-outcome/questions/q1.txt
+++ b/spec/fixtures/acceptance/question-and-outcome/questions/q1.txt
@@ -5,5 +5,6 @@ Body text line 1.
 Body text
 para 2.
 
+[choice: q1]
 * yes: Yes
 * no: No

--- a/spec/parser/element/multiple_choice_question_spec.rb
+++ b/spec/parser/element/multiple_choice_question_spec.rb
@@ -4,28 +4,64 @@ require 'smartdown/parser/node_interpreter'
 
 describe Smartdown::Parser::Element::MultipleChoiceQuestion do
   subject(:parser) { described_class.new }
-  let(:source) {
-    [
-      "* yes: Yes",
-      "* no: No"
-    ].join("\n")
-  }
 
-  it "parses" do
-    should parse(source).as(
-      multiple_choice: [
-        {value: "yes", label: "Yes"},
-        {value: "no", label: "No"}
-      ]
-    )
-  end
-
-  describe "transformed" do
-    let(:node_name) { "my_node" }
-    subject(:transformed) {
-      Smartdown::Parser::NodeInterpreter.new(node_name, source, parser: parser).interpret
+  context "with question tag" do
+    let(:source) {
+      [
+        "[choice: yes_or_no]",
+        "* yes: Yes",
+        "* no: No"
+      ].join("\n")
     }
 
-    it { should eq(Smartdown::Model::Element::MultipleChoice.new(node_name, {"yes"=>"Yes", "no"=>"No"})) }
+    it "parses" do
+      should parse(source).as(
+        multiple_choice: {
+          identifier: "yes_or_no",
+          options: [
+            {value: "yes", label: "Yes"},
+            {value: "no", label: "No"}
+          ]
+        }
+      )
+    end
+
+    describe "transformed" do
+      let(:node_name) { "my_node" }
+      subject(:transformed) {
+        Smartdown::Parser::NodeInterpreter.new(node_name, source, parser: parser).interpret
+      }
+
+      it { should eq(Smartdown::Model::Element::MultipleChoice.new("yes_or_no", {"yes"=>"Yes", "no"=>"No"})) }
+    end
+  end
+
+  context "without question tag" do
+    let(:source) {
+      [
+        "* yes: Yes",
+        "* no: No"
+      ].join("\n")
+    }
+
+    it "parses" do
+      should parse(source).as(
+        multiple_choice: {
+          options: [
+            {value: "yes", label: "Yes"},
+            {value: "no", label: "No"}
+          ]
+        }
+      )
+    end
+
+    describe "transformed" do
+      let(:node_name) { "my_node" }
+      subject(:transformed) {
+        Smartdown::Parser::NodeInterpreter.new(node_name, source, parser: parser).interpret
+      }
+
+      it { should eq(Smartdown::Model::Element::MultipleChoice.new(node_name, {"yes"=>"Yes", "no"=>"No"})) }
+    end
   end
 end

--- a/spec/parser/element/multiple_choice_question_spec.rb
+++ b/spec/parser/element/multiple_choice_question_spec.rb
@@ -44,24 +44,8 @@ describe Smartdown::Parser::Element::MultipleChoiceQuestion do
       ].join("\n")
     }
 
-    it "parses" do
-      should parse(source).as(
-        multiple_choice: {
-          options: [
-            {value: "yes", label: "Yes"},
-            {value: "no", label: "No"}
-          ]
-        }
-      )
-    end
-
-    describe "transformed" do
-      let(:node_name) { "my_node" }
-      subject(:transformed) {
-        Smartdown::Parser::NodeInterpreter.new(node_name, source, parser: parser).interpret
-      }
-
-      it { should eq(Smartdown::Model::Element::MultipleChoice.new(node_name, {"yes"=>"Yes", "no"=>"No"})) }
+    it "is not parsable" do
+      should_not parse(source)
     end
   end
 end

--- a/spec/parser/node_parser_spec.rb
+++ b/spec/parser/node_parser_spec.rb
@@ -60,6 +60,7 @@ SOURCE
 <<SOURCE
 # This is my title
 
+[choice: my_question]
 * yes: Yes
 * no: No
 SOURCE
@@ -70,6 +71,7 @@ SOURCE
         body: [
           {h1: "This is my title"},
           {multiple_choice: {
+            identifier: "my_question",
             options: [
               {value: "yes", label: "Yes"},
               {value: "no", label: "No"}
@@ -85,6 +87,7 @@ SOURCE
 <<SOURCE
 # This is my title
 
+[choice: my_question]
 * yes: Yes
 * no: No
 
@@ -99,6 +102,7 @@ SOURCE
         body: [
           {h1: "This is my title"},
           {multiple_choice: {
+            identifier: "my_question",
             options: [
               {value: "yes", label: "Yes"},
               {value: "no", label: "No"}
@@ -119,7 +123,7 @@ SOURCE
       let(:expected_elements) {
         [
           Smartdown::Model::Element::MarkdownHeading.new("This is my title"),
-          Smartdown::Model::Element::MultipleChoice.new(node_name, "yes"=>"Yes", "no"=>"No"),
+          Smartdown::Model::Element::MultipleChoice.new("my_question", "yes"=>"Yes", "no"=>"No"),
           Smartdown::Model::Element::MarkdownHeading.new("Next node rules"),
           Smartdown::Model::NextNodeRules.new([
             Smartdown::Model::Rule.new(Smartdown::Model::Predicate::Named.new("pred1?"), "outcome")

--- a/spec/parser/node_parser_spec.rb
+++ b/spec/parser/node_parser_spec.rb
@@ -69,10 +69,12 @@ SOURCE
       should parse(source).as({
         body: [
           {h1: "This is my title"},
-          {multiple_choice: [
-            {value: "yes", label: "Yes"},
-            {value: "no", label: "No"}
-          ]}
+          {multiple_choice: {
+            options: [
+              {value: "yes", label: "Yes"},
+              {value: "no", label: "No"}
+            ]}
+          }
         ]
       })
     end
@@ -96,10 +98,12 @@ SOURCE
       should parse(source).as({
         body: [
           {h1: "This is my title"},
-          {multiple_choice: [
-            {value: "yes", label: "Yes"},
-            {value: "no", label: "No"}
-          ]},
+          {multiple_choice: {
+            options: [
+              {value: "yes", label: "Yes"},
+              {value: "no", label: "No"}
+            ]}
+          },
           {h1: "Next node rules"},
           {next_node_rules: [{rule: {predicate: {named_predicate: "pred1?"}, outcome: "outcome"}}]}
         ]


### PR DESCRIPTION
The syntax is:

```
[choice: question_name]
* opt1: Opt label 1
* opt2: Opt label 2
```

this will create a multiple choice question with the given name. The
label is required.
