### PR TITLE
Support for conditionals in outcomes

### DIFF
--- a/bin/smartdown
+++ b/bin/smartdown
@@ -25,7 +25,7 @@ else
 
     puts "RESPONSES: " + end_state.get(:responses).join(" / ")
     puts "PATH: " + (end_state.get(:path) + [end_state.get(:current_node)]).join(" -> ")
-    node = flow.node(end_state.get(:current_node))
+    node = engine.evaluate_node(end_state)
     puts "# #{node.title}\n\n"
     node.questions.each do |q|
       pp q.choices

--- a/lib/smartdown/engine.rb
+++ b/lib/smartdown/engine.rb
@@ -1,5 +1,6 @@
 require 'smartdown/engine/transition'
 require 'smartdown/engine/state'
+require 'smartdown/engine/node_presenter'
 
 module Smartdown
   class Engine
@@ -28,6 +29,11 @@ module Smartdown
         current_node = flow.node(state.get(:current_node))
         Transition.new(state, current_node, input).next_state
       end
+    end
+
+    def evaluate_node(state)
+      current_node = flow.node(state.get(:current_node))
+      NodePresenter.new.present(current_node, state)
     end
   end
 end

--- a/lib/smartdown/engine/node_presenter.rb
+++ b/lib/smartdown/engine/node_presenter.rb
@@ -1,0 +1,38 @@
+require 'smartdown/engine/predicate_evaluator'
+
+module Smartdown
+  class Engine
+    class NodePresenter
+      def initialize(predicate_evaluator = nil)
+        @predicate_evaluator = predicate_evaluator || PredicateEvaluator.new
+      end
+
+      def present(node, state)
+        node.dup.tap do |new_node|
+          new_node.elements = resolve_conditionals(node.elements, state)
+        end
+      end
+
+    private
+      attr_accessor :predicate_evaluator
+
+      def evaluate(conditional, state)
+        if predicate_evaluator.evaluate(conditional.predicate, state)
+          conditional.true_case
+        else
+          conditional.false_case
+        end
+      end
+
+      def resolve_conditionals(elements, state)
+        elements.map do |element|
+          if element.is_a?(Smartdown::Model::Element::Conditional)
+            evaluate(element, state)
+          else
+            element
+          end
+        end.flatten
+      end
+    end
+  end
+end

--- a/lib/smartdown/model/element/conditional.rb
+++ b/lib/smartdown/model/element/conditional.rb
@@ -1,0 +1,7 @@
+module Smartdown
+  module Model
+    module Element
+      Conditional = Struct.new(:predicate, :true_case, :false_case)
+    end
+  end
+end

--- a/lib/smartdown/parser/element/conditional.rb
+++ b/lib/smartdown/parser/element/conditional.rb
@@ -1,0 +1,37 @@
+require 'smartdown/parser/base'
+require 'smartdown/parser/node_parser'
+require 'smartdown/parser/predicates'
+
+module Smartdown
+  module Parser
+    module Element
+      class Conditional < Base
+        rule(:markdown_block_inside_conditional) {
+          str("$").absent? >> NodeParser.new.markdown_block
+        }
+
+        rule(:markdown_blocks_inside_conditional) {
+          markdown_block_inside_conditional.repeat(1,1) >> (newline.repeat(1) >> markdown_block_inside_conditional).repeat
+        }
+
+        rule(:else_clause) {
+          str("$ELSE") >> optional_space >> newline.repeat(2) >>
+            (markdown_blocks_inside_conditional.as(:false_case) >> newline).maybe
+        }
+
+        rule(:conditional_clause) {
+          (
+            str("$IF ") >>
+              Predicates.new.as(:predicate) >>
+              optional_space >> newline.repeat(2) >>
+              (markdown_blocks_inside_conditional.as(:true_case) >> newline).maybe >>
+              else_clause.maybe >>
+              str("$ENDIF") >> optional_space >> line_ending
+          ).as(:conditional)
+        }
+
+        root(:conditional_clause)
+      end
+    end
+  end
+end

--- a/lib/smartdown/parser/node_parser.rb
+++ b/lib/smartdown/parser/node_parser.rb
@@ -20,7 +20,7 @@ module Smartdown
       }
 
       rule(:markdown_blocks) {
-        markdown_block >> (newline.repeat(1) >> markdown_block).repeat
+        markdown_block.repeat(1, 1) >> (newline.repeat(1) >> markdown_block).repeat
       }
 
       rule(:body) {

--- a/lib/smartdown/parser/node_parser.rb
+++ b/lib/smartdown/parser/node_parser.rb
@@ -5,12 +5,14 @@ require 'smartdown/parser/element/start_button'
 require 'smartdown/parser/element/multiple_choice_question'
 require 'smartdown/parser/element/markdown_heading'
 require 'smartdown/parser/element/markdown_paragraph'
+require 'smartdown/parser/element/conditional'
 
 module Smartdown
   module Parser
     class NodeParser < Base
       rule(:markdown_block) {
-        Element::MarkdownHeading.new |
+        Element::Conditional.new |
+          Element::MarkdownHeading.new |
           Element::MultipleChoiceQuestion.new |
           Rules.new |
           Element::StartButton.new |

--- a/lib/smartdown/parser/node_transform.rb
+++ b/lib/smartdown/parser/node_transform.rb
@@ -8,6 +8,7 @@ require 'smartdown/model/element/multiple_choice'
 require 'smartdown/model/element/start_button'
 require 'smartdown/model/element/markdown_heading'
 require 'smartdown/model/element/markdown_paragraph'
+require 'smartdown/model/element/conditional'
 require 'smartdown/model/predicate/equality'
 require 'smartdown/model/predicate/set_membership'
 require 'smartdown/model/predicate/named'
@@ -53,6 +54,28 @@ module Smartdown
         Smartdown::Model::Element::MultipleChoice.new(
           node_name, Hash[choices]
         )
+      }
+
+      # Conditional with no content in true-case
+      rule(:conditional => {:predicate => subtree(:predicate)}) {
+        Smartdown::Model::Element::Conditional.new(predicate)
+      }
+
+      # Conditional with content in true-case
+      rule(:conditional => {
+             :predicate => subtree(:predicate),
+             :true_case => subtree(:true_case)
+           }) {
+        Smartdown::Model::Element::Conditional.new(predicate, true_case)
+      }
+
+      # Conditional with content in both true-case and false-case
+      rule(:conditional => {
+             :predicate => subtree(:predicate),
+             :true_case => subtree(:true_case),
+             :false_case => subtree(:false_case)
+           }) {
+        Smartdown::Model::Element::Conditional.new(predicate, true_case, false_case)
       }
 
       rule(:equality_predicate => { varname: simple(:varname), expected_value: simple(:expected_value) }) {

--- a/spec/engine/node_presenter_spec.rb
+++ b/spec/engine/node_presenter_spec.rb
@@ -1,0 +1,60 @@
+require 'smartdown/engine/node_presenter'
+require 'smartdown/engine/state'
+
+describe Smartdown::Engine::NodePresenter do
+  subject(:node_presenter) { described_class.new }
+
+  context "a node with a conditional" do
+    let(:node) {
+      model_builder.node("outcome_no_visa_needed") do
+        conditional do
+          named_predicate "pred?"
+          true_case do
+            paragraph("True case")
+          end
+          false_case do
+            paragraph("False case")
+          end
+        end
+      end
+    }
+
+    context "pred is true" do
+      let(:state) {
+        Smartdown::Engine::State.new(
+          current_node: node.name,
+          pred?: true
+        )
+      }
+
+      let(:expected_node_after_presentation) {
+        model_builder.node("outcome_no_visa_needed") do
+          paragraph("True case")
+        end
+      }
+
+      it "should resolve the conditional and preserve the 'True case' paragraph block" do
+        expect(node_presenter.present(node, state)).to eq(expected_node_after_presentation)
+      end
+    end
+
+    context "pred is false" do
+      let(:state) {
+        Smartdown::Engine::State.new(
+          current_node: node.name,
+          pred?: false
+        )
+      }
+
+      let(:expected_node_after_presentation) {
+        model_builder.node("outcome_no_visa_needed") do
+          paragraph("False case")
+        end
+      }
+
+      it "should resolve the conditional and preserve the 'False case' paragraph block" do
+        expect(node_presenter.present(node, state)).to eq(expected_node_after_presentation)
+      end
+    end
+  end
+end

--- a/spec/engine_spec.rb
+++ b/spec/engine_spec.rb
@@ -29,6 +29,18 @@ describe Smartdown::Engine do
           end
         end
       end
+
+      node("outcome_no_visa_needed") do
+        conditional do
+          named_predicate "pred?"
+          true_case do
+            paragraph("True case")
+          end
+          false_case do
+            paragraph("False case")
+          end
+        end
+      end
     end
   }
 
@@ -47,11 +59,13 @@ describe Smartdown::Engine do
     context "start button response only" do
       let(:responses) { %w{yes} }
 
-      it "is on what_passport_do_you_have?" do
+      it { should be_a(Smartdown::Engine::State) }
+
+      it "current_node of 'what_passport_do_you_have?'" do
         expect(subject.get(:current_node)).to eq("what_passport_do_you_have?")
       end
 
-      it "has recorded input" do
+      it "input recorded in state variable corresponding to node name" do
         expect(subject.get("check-uk-visa")).to eq("yes")
       end
     end
@@ -59,7 +73,7 @@ describe Smartdown::Engine do
     context "greek passport" do
       let(:responses) { %w{yes greek} }
 
-      it "is on what_passport_do_you_have?" do
+      it "is on outcome_no_visa_needed" do
         expect(subject.get(:current_node)).to eq("outcome_no_visa_needed")
       end
 
@@ -76,4 +90,23 @@ describe Smartdown::Engine do
       end
     end
   end
+
+  describe "#evaluate_node" do
+    let(:current_state) {
+      start_state
+        .put(:current_node, "outcome_no_visa_needed")
+        .put(:pred?, true)
+    }
+
+    let(:expected_node_after_conditional_resolution) {
+      model_builder.node("outcome_no_visa_needed") do
+        paragraph("True case")
+      end
+    }
+
+    it "evaluates the current node of the given state, resolving any conditionals" do
+      expect(engine.evaluate_node(current_state)).to eq(expected_node_after_conditional_resolution)
+    end
+  end
+
 end

--- a/spec/parser/element/conditional_spec.rb
+++ b/spec/parser/element/conditional_spec.rb
@@ -1,0 +1,99 @@
+require 'smartdown/parser/element/conditional'
+require 'smartdown/parser/node_interpreter'
+
+describe Smartdown::Parser::Element::Conditional do
+
+  subject(:parser) { described_class.new }
+  let(:node_name) { "my_node" }
+
+  context "simple IF" do
+    let(:source) { <<-SOURCE
+$IF pred1?
+
+#{true_body}
+
+$ENDIF
+SOURCE
+    }
+
+    context "with one-line true case" do
+      let(:true_body) { "Text if true" }
+
+      it {
+        should parse(source).as(
+          conditional: {
+            predicate: {named_predicate: "pred1?"},
+            true_case: [{p: "#{true_body}\n"}]
+          }
+        )
+      }
+
+      xdescribe "transformed" do
+        subject(:transformed) {
+          Smartdown::Parser::NodeInterpreter.new(node_name, source, parser: parser).interpret
+        }
+
+        it { should eq(Smartdown::Model::Element::MarkdownParagraph.new(content)) }
+      end
+
+    end
+
+    context "with multi-line true case" do
+      let(:one_line) { "Text if true" }
+      let(:true_body) { "#{one_line}\n\n#{one_line}" }
+
+      it {
+        should parse(source).as(
+          conditional: {
+            predicate: {named_predicate: "pred1?"},
+            true_case: [{p: "#{one_line}\n"}, {p: "#{one_line}\n"}]
+          }
+        )
+      }
+    end
+
+    context "with empty true case case" do
+      let(:true_body) { "" }
+
+      it {
+        should parse(source).as(
+          conditional: {
+            predicate: {named_predicate: "pred1?"}
+          }
+        )
+      }
+    end
+  end
+
+  context "simple IF-ELSE" do
+    let(:source) { <<-SOURCE
+$IF pred1?
+
+#{true_body}
+
+$ELSE
+
+#{false_body}
+
+$ENDIF
+SOURCE
+    }
+
+    context "with one-line true case" do
+      let(:true_body) { "Text if true" }
+      let(:false_body) { "Text if false" }
+
+      it {
+        should parse(source).as(
+          conditional: {
+            predicate: {named_predicate: "pred1?"},
+            true_case: [{p: "#{true_body}\n"}],
+            false_case: [{p: "#{false_body}\n"}]
+          }
+        )
+      }
+    end
+  end
+
+end
+

--- a/spec/parser/element/conditional_spec.rb
+++ b/spec/parser/element/conditional_spec.rb
@@ -28,12 +28,19 @@ SOURCE
         )
       }
 
-      xdescribe "transformed" do
+      describe "transformed" do
         subject(:transformed) {
           Smartdown::Parser::NodeInterpreter.new(node_name, source, parser: parser).interpret
         }
 
-        it { should eq(Smartdown::Model::Element::MarkdownParagraph.new(content)) }
+        it {
+          should eq(
+            Smartdown::Model::Element::Conditional.new(
+              Smartdown::Model::Predicate::Named.new("pred1?"),
+              [Smartdown::Model::Element::MarkdownParagraph.new(true_body + "\n")]
+            )
+          )
+        }
       end
 
     end
@@ -50,6 +57,24 @@ SOURCE
           }
         )
       }
+
+      describe "transformed" do
+        subject(:transformed) {
+          Smartdown::Parser::NodeInterpreter.new(node_name, source, parser: parser).interpret
+        }
+
+        it {
+          should eq(
+            Smartdown::Model::Element::Conditional.new(
+              Smartdown::Model::Predicate::Named.new("pred1?"),
+              [
+                Smartdown::Model::Element::MarkdownParagraph.new(one_line + "\n"),
+                Smartdown::Model::Element::MarkdownParagraph.new(one_line + "\n")
+              ]
+            )
+          )
+        }
+      end
     end
 
     context "with empty true case case" do
@@ -62,6 +87,20 @@ SOURCE
           }
         )
       }
+
+      describe "transformed" do
+        subject(:transformed) {
+          Smartdown::Parser::NodeInterpreter.new(node_name, source, parser: parser).interpret
+        }
+
+        it {
+          should eq(
+            Smartdown::Model::Element::Conditional.new(
+              Smartdown::Model::Predicate::Named.new("pred1?")
+            )
+          )
+        }
+      end
     end
   end
 
@@ -92,6 +131,22 @@ SOURCE
           }
         )
       }
+
+      describe "transformed" do
+        subject(:transformed) {
+          Smartdown::Parser::NodeInterpreter.new(node_name, source, parser: parser).interpret
+        }
+
+        it {
+          should eq(
+            Smartdown::Model::Element::Conditional.new(
+              Smartdown::Model::Predicate::Named.new("pred1?"),
+              [Smartdown::Model::Element::MarkdownParagraph.new(true_body + "\n")],
+              [Smartdown::Model::Element::MarkdownParagraph.new(false_body + "\n")]
+            )
+          )
+        }
+      end
     end
   end
 

--- a/spec/parser/node_parser_spec.rb
+++ b/spec/parser/node_parser_spec.rb
@@ -130,4 +130,32 @@ SOURCE
       it { should eq(expected_node_model) }
     end
   end
+
+  describe "body with conditional" do
+    let(:source) {
+<<SOURCE
+$IF pred1?
+
+Text when true
+
+$ELSE
+
+Text when false
+
+$ENDIF
+SOURCE
+     }
+
+    it {
+      should parse(source).as({
+        body: [
+          {conditional: {
+            predicate: {named_predicate: "pred1?"},
+            true_case: [{p: "Text when true\n"}],
+            false_case: [{p: "Text when false\n"}]
+          }}
+        ]
+      })
+    }
+  end
 end

--- a/spec/support/model_builder.rb
+++ b/spec/support/model_builder.rb
@@ -105,8 +105,12 @@ class ModelBuilder
   end
 
   module DSL
+    def model_builder
+      ModelBuilder.new
+    end
+
     def build_flow(name, &block)
-      ModelBuilder.new.flow(name, &block)
+      model_builder.flow(name, &block)
     end
   end
 end

--- a/spec/support/model_builder.rb
+++ b/spec/support/model_builder.rb
@@ -4,6 +4,7 @@ require 'smartdown/model/element/markdown_heading'
 require 'smartdown/model/element/markdown_paragraph'
 require 'smartdown/model/element/start_button'
 require 'smartdown/model/element/multiple_choice'
+require 'smartdown/model/element/conditional'
 require 'smartdown/model/next_node_rules'
 require 'smartdown/model/rule'
 require 'smartdown/model/predicate/named'
@@ -65,6 +66,34 @@ class ModelBuilder
     instance_eval(&block) if block_given?
     @rules << Smartdown::Model::Rule.new(@predicate, @outcome)
     @rules.last
+  end
+
+  def conditional(&block)
+    @predicate = nil
+    @true_case = nil
+    @false_case = nil
+    @elements ||= []
+    instance_eval(&block) if block_given?
+    @elements << Smartdown::Model::Element::Conditional.new(@predicate, @true_case, @false_case)
+    @elements.last
+  end
+
+  def true_case(&block)
+    @outer_elements = @elements
+    @elements = []
+    instance_eval(&block) if block_given?
+    @true_case = @elements
+    @elements = @outer_elements
+    @true_case
+  end
+
+  def false_case(&block)
+    @outer_elements = @elements
+    @elements = []
+    instance_eval(&block) if block_given?
+    @false_case = @elements
+    @elements = @outer_elements
+    @false_case
   end
 
   def named_predicate(name)

--- a/spec/support_specs/model_builder_spec.rb
+++ b/spec/support_specs/model_builder_spec.rb
@@ -62,6 +62,32 @@ describe ModelBuilder do
     end
   end
 
+  describe "#conditional" do
+    let(:expected) {
+      Smartdown::Model::Element::Conditional.new(
+        Smartdown::Model::Predicate::Named.new("pred?"),
+        [Smartdown::Model::Element::MarkdownParagraph.new("True case")],
+        [Smartdown::Model::Element::MarkdownParagraph.new("False case")]
+      )
+    }
+
+    subject(:model) {
+      builder.conditional do
+        named_predicate "pred?"
+        true_case do
+          paragraph("True case")
+        end
+        false_case do
+          paragraph("False case")
+        end
+      end
+    }
+
+    it "builds a conditional" do
+      should eq(expected)
+    end
+  end
+
   describe "#rule" do
     let(:predicate) { Smartdown::Model::Predicate::Named.new("my_pred") }
 


### PR DESCRIPTION
Adds support for conditional blocks in outcomes. 

The syntax is:

``` markdown
$IF pred?

Text if true

more text if you like

$ENDIF
```

You can also have an else clause:

``` markdown
$IF pred?

Text if true

$ELSE

Text if false

$ENDIF
```

It's required to have a blank line between each if statement and the next paragraph of text, in other words this would be **invalid**:

``` markdown
$IF pred?
Text if true
$ENDIF
```

If you call `Engine#process` you will get a state object back. If you then want to evaluate the node in that state to resolve conditionals you must call `Engine#evaluate_node(state)` which will evaluate the `current_node` as defined by the `state`. I had considered making `Engine#process` return a tuple of `(state, evaluated_node)`, but not sure if you would want to always evaluate the node. Thoughts welcome.
