### PR TITLE
Bump to version 0.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+## 0.0.3
+
+* support for conditionals
+* mandatory 'tag' on choice questions in the form:
+
+```
+[choice: question_name]
+* opt1: Option one
+* opt2: Option two
+```

--- a/lib/smartdown/version.rb
+++ b/lib/smartdown/version.rb
@@ -1,3 +1,3 @@
 module Smartdown
-  VERSION = "0.0.2"
+  VERSION = "0.0.3"
 end


### PR DESCRIPTION
# Changelog
## 0.0.3
- support for conditionals
- mandatory 'tag' on choice questions in the form:

```
[choice: question_name]
* opt1: Option one
* opt2: Option two
```
