### PR TITLE
Get next node from start button

### DIFF
--- a/lib/smartdown/engine/transition.rb
+++ b/lib/smartdown/engine/transition.rb
@@ -14,7 +14,9 @@ module Smartdown
       end
 
       def next_node
-        first_matching_rule(next_node_rules.rules).outcome
+        next_node_from_next_node_rules ||
+          next_node_from_start_button ||
+          raise(Smartdown::Engine::IndeterminateNextNode, "No next node rules defined for '#{node.name}'", caller)
       end
 
       def next_state
@@ -28,9 +30,20 @@ module Smartdown
     private
       attr_reader :predicate_evaluator
 
+      def next_node_from_next_node_rules
+        next_node_rules && first_matching_rule(next_node_rules.rules).outcome
+      end
+
+      def next_node_from_start_button
+        start_button && start_button.start_node
+      end
+
       def next_node_rules
-        node.elements.find { |e| e.is_a?(Smartdown::Model::NextNodeRules) } or \
-          raise Smartdown::Engine::IndeterminateNextNode, "No next node rules defined for '#{node.name}'"
+        node.elements.find { |e| e.is_a?(Smartdown::Model::NextNodeRules) }
+      end
+
+      def start_button
+        node.elements.find { |e| e.is_a?(Smartdown::Model::Element::StartButton) }
       end
 
       def first_matching_rule(rules)

--- a/spec/engine/transition_spec.rb
+++ b/spec/engine/transition_spec.rb
@@ -25,6 +25,20 @@ describe Smartdown::Engine::Transition do
     end
   end
 
+  context "no next node rules, but start button" do
+    let(:current_node) {
+      Smartdown::Model::Node.new(current_node_name, [
+        Smartdown::Model::Element::StartButton.new("first_question")
+      ])
+    }
+
+    describe "#next_node" do
+      it "take the next node from the start button" do
+        expect(transition.next_node).to eq("first_question")
+      end
+    end
+  end
+
   context "next node rules defined with a simple rule" do
     let(:predicate1) { double("predicate1") }
     let(:outcome_name1) { "o1" }

--- a/spec/engine_spec.rb
+++ b/spec/engine_spec.rb
@@ -7,12 +7,6 @@ describe Smartdown::Engine do
         heading("Check uk visa")
         paragraph("This is the paragraph")
         start_button("what_passport_do_you_have?")
-        next_node_rules do
-          rule do
-            named_predicate("otherwise")
-            outcome("what_passport_do_you_have?")
-          end
-        end
       end
 
       node("what_passport_do_you_have?") do


### PR DESCRIPTION
Tidying up, this was intended behaviour all along. If next node rules are not
defined then next node will be taken from start button.
