### PR TITLE
Use question name for input variable name

### DIFF
--- a/lib/smartdown/engine/transition.rb
+++ b/lib/smartdown/engine/transition.rb
@@ -23,7 +23,7 @@ module Smartdown
         state_with_input
           .put(:path, state.get(:path) + [node.name])
           .put(:responses, state.get(:responses) + [input])
-          .put(node.name, input)
+          .put(input_variable_name, input)
           .put(:current_node, next_node)
       end
 
@@ -36,6 +36,15 @@ module Smartdown
 
       def next_node_from_start_button
         start_button && start_button.start_node
+      end
+
+      def input_variable_name
+        input_variable_name_from_question || node.name
+      end
+
+      def input_variable_name_from_question
+        question = node.elements.find { |e| e.is_a?(Smartdown::Model::Element::MultipleChoice) }
+        question && question.name
       end
 
       def next_node_rules


### PR DESCRIPTION
The next-node transition rules have until now been independent from
question definitions. However, now that questions can be named
explicitly then we should use the question name when capturing the input
value.

It was an oversight to have missed this when I implemented the choice
question tag with an explicit question name.
