### PR TITLE
[merge third] Move smartdown adapter logic to the gem

### DIFF
--- a/lib/smartdown/api/coversheet.rb
+++ b/lib/smartdown/api/coversheet.rb
@@ -1,0 +1,7 @@
+require 'smartdown/api/node'
+module Smartdown
+  module Api
+    class Coversheet < Node
+    end
+  end
+end

--- a/lib/smartdown/api/flow.rb
+++ b/lib/smartdown/api/flow.rb
@@ -1,0 +1,115 @@
+require 'smartdown'
+require 'smartdown/engine'
+require 'smartdown/api/state'
+require 'smartdown/api/coversheet'
+require 'smartdown/api/question_page'
+require 'smartdown/api/outcome'
+
+module Smartdown
+  module Api
+    class Flow
+
+      def initialize(smartdown_input)
+        @smartdown_flow = Smartdown::Parser::FlowInterpreter.new(smartdown_input).interpret
+        @engine = Smartdown::Engine.new(@smartdown_flow)
+      end
+
+      def state(started, responses)
+        state = smartdown_state(started, responses)
+        State.new(transform_node(node_by_name(state.get(:current_node))),
+                  previous_question_nodes_for(state),
+                  responses
+        )
+      end
+
+      def title
+        coversheet.title
+      end
+
+      def meta_description
+        front_matter.meta_description
+      end
+
+      def need_id
+        front_matter.satisfies_need
+      end
+
+      def status
+        front_matter.status
+      end
+
+      def draft?
+        status == 'draft'
+      end
+
+      def transition?
+        status == 'transition'
+      end
+
+      def published?
+        status == 'published'
+      end
+
+      def nodes
+        @smartdown_flow.nodes.map{ |node| transform_node(node) }
+          .select{ |node| (node.is_a? Smartdown::Api::QuestionPage) ||
+                          (node.is_a? Smartdown::Api::Outcome)
+        }
+      end
+
+      def question_pages
+        nodes.select{ |node| node.is_a? Smartdown::Api::QuestionPage }
+      end
+
+      def outcomes
+        nodes.select{ |node| node.is_a? Smartdown::Api::Outcome}
+      end
+
+    private
+
+      def transform_node(node)
+        if node.elements.any?{|element| element.is_a? Smartdown::Model::Element::StartButton}
+          Smartdown::Api::Coversheet.new(node)
+        elsif node.elements.any?{|element| element.is_a? Smartdown::Model::NextNodeRules}
+          if node.elements.any?{|element| element.is_a? Smartdown::Model::Element::MultipleChoice}
+            Smartdown::Api::QuestionPage.new(node)
+          else
+            #TODO: support other types of questions
+          end
+        else
+          Smartdown::Api::Outcome.new(node)
+        end
+      end
+
+      def coversheet
+        @coversheet ||= Smartdown::Api::Coversheet.new(@smartdown_flow.coversheet)
+      end
+
+      def front_matter
+        @front_matter ||= coversheet.front_matter
+      end
+
+      def smartdown_state(started, responses)
+        smartdown_responses = responses.clone
+        if started
+          smartdown_responses.unshift('y')
+        end
+        @engine.process(smartdown_responses)
+      end
+
+      def node_by_name(node_name)
+        @smartdown_flow.node(node_name)
+      end
+
+      def previous_question_nodes_for(state)
+        node_path = state.get('path')
+        return [] if node_path.empty?
+
+        node_path[1..-1].map do |node_name|
+          node_by_name(node_name)
+        end
+      end
+
+    end
+  end
+end

--- a/lib/smartdown/api/multiple_choice.rb
+++ b/lib/smartdown/api/multiple_choice.rb
@@ -1,0 +1,25 @@
+require 'smartdown/api/question'
+
+module Smartdown
+  module Api
+    class MultipleChoice < Question
+      def options
+        question = elements.find{|element| element.is_a? Smartdown::Model::Element::MultipleChoice}
+        question.choices.map do |choice|
+          OpenStruct.new(:label => choice[1], :value => choice[0])
+        end
+      end
+
+      def name
+        question = elements.find{|element| element.is_a? Smartdown::Model::Element::MultipleChoice}
+        question.name
+      end
+
+      #TODO: move to presenters in smart-answer app
+      def partial_template_name
+        "multiple_choice_question"
+      end
+
+    end
+  end
+end

--- a/lib/smartdown/api/node.rb
+++ b/lib/smartdown/api/node.rb
@@ -1,0 +1,67 @@
+module Smartdown
+  module Api
+    class Node
+
+      attr_reader :title ,:elements, :front_matter, :name
+
+      def initialize(node)
+        node_elements = node.elements.clone
+        headings = node_elements.select {
+            |element| element.is_a? Smartdown::Model::Element::MarkdownHeading
+        }
+        @title = headings.first.content.to_s if headings.first
+        node_elements.delete(headings.first) #Remove page title
+        @elements = node_elements
+        @front_matter = node.front_matter
+        @name = node.name
+      end
+
+      def has_title?
+        !!title
+      end
+
+      def body
+        elements_before_smartdown = elements.take_while{|element| !smartdown_element?(element)}
+        build_govspeak(elements_before_smartdown)
+      end
+
+      def has_body?
+        !!body
+      end
+
+      def has_devolved_body?
+        !!devolved_body
+      end
+
+      def devolved_body
+        elements_after_smartdown = elements.drop_while{|element| !smartdown_element?(element)}
+        build_govspeak(elements_after_smartdown)
+      end
+
+      def next_nodes
+        elements.select{ |element| element.is_a? Smartdown::Model::NextNodeRules }
+      end
+
+      def permitted_next_nodes
+        next_nodes
+      end
+
+    private
+
+      def markdown_element?(element)
+        (element.is_a? Smartdown::Model::Element::MarkdownParagraph) || (element.is_a? Smartdown::Model::Element::MarkdownHeading)
+      end
+
+      def smartdown_element?(element)
+        !markdown_element?(element)
+      end
+
+      def build_govspeak(elements)
+        markdown_elements = elements.select do |element|
+          markdown_element?(element)
+        end
+        GovspeakPresenter.new(markdown_elements.map(&:content).join("\n")).html
+      end
+    end
+  end
+end

--- a/lib/smartdown/api/outcome.rb
+++ b/lib/smartdown/api/outcome.rb
@@ -1,0 +1,16 @@
+module Smartdown
+  module Api
+    class Outcome < Node
+
+      def has_next_steps?
+        !!next_steps
+      end
+
+      def next_steps
+        next_step_element = elements.find{|element| element.is_a? Smartdown::Model::Element::NextSteps}
+        GovspeakPresenter.new(next_step_element.content).html if next_step_element
+      end
+
+    end
+  end
+end

--- a/lib/smartdown/api/previous_question.rb
+++ b/lib/smartdown/api/previous_question.rb
@@ -1,0 +1,31 @@
+module Smartdown
+  module Api
+    class PreviousQuestion
+
+      attr_reader :response, :title
+
+      def initialize(title, question_element, response, modifiable)
+        @title = title
+        @question_element = question_element
+        @response = response
+        @modifiable = modifiable
+      end
+
+      #TODO: remove need for this method by impleemnting modification properly
+      def modifiable?
+        @modifiable
+      end
+
+      #TODO: to be moved to presenter
+      def multiple_responses?
+        false
+      end
+
+      #TODO: move to presenter, this object API should only expose question_element.choices
+      def response_label(value=response)
+        @question_element.choices.fetch(value)
+      end
+
+    end
+  end
+end

--- a/lib/smartdown/api/question.rb
+++ b/lib/smartdown/api/question.rb
@@ -1,0 +1,76 @@
+module Smartdown
+  module Api
+    class Question
+
+      attr_reader :number
+
+      def initialize(elements, number=nil)
+        @elements = elements
+        @number = number
+      end
+
+      #TODO: this assumes the title is the first element
+      def title
+        elements.first.content
+      end
+
+      def has_body?
+        !!body
+      end
+
+      def body
+        elements_before_smartdown = elements[1..-1].take_while{|element| !smartdown_element?(element)}
+        build_govspeak(elements_before_smartdown)
+      end
+
+      def has_hint?
+        !!hint
+      end
+
+      #TODO: confirm we can delete this
+      # Usage TBC, most hints should actually be `body`s, semi-deprecated
+      # As we transition content we should better define it, or remove it
+      def hint
+      end
+
+      def prefix
+        "todo prefix"
+      end
+
+      def suffix
+        "todo suffix"
+      end
+
+      def subtitle
+        "todo subtitle"
+      end
+
+      #TODO
+      def error
+      end
+
+      #TODO: should not be needed
+      def responses
+      end
+
+    private
+
+      attr_reader :elements
+
+      def markdown_element?(element)
+        (element.is_a? Smartdown::Model::Element::MarkdownParagraph) || (element.is_a? Smartdown::Model::Element::MarkdownHeading)
+      end
+
+      def smartdown_element?(element)
+        !markdown_element?(element)
+      end
+
+      def build_govspeak(elements)
+        markdown_elements = elements.select do |element|
+          markdown_element?(element)
+        end
+        GovspeakPresenter.new(markdown_elements.map(&:content).join("\n")).html
+      end
+    end
+  end
+end

--- a/lib/smartdown/api/question_page.rb
+++ b/lib/smartdown/api/question_page.rb
@@ -1,0 +1,15 @@
+require 'smartdown/api/multiple_choice'
+
+module Smartdown
+  module Api
+    class QuestionPage < Node
+      def questions
+        elements.slice_before do |element|
+          element.is_a? Smartdown::Model::Element::MarkdownHeading
+        end.each_with_index.map do |question_element_group, index|
+          Smartdown::Api::MultipleChoice.new(question_element_group, index+1)
+        end
+      end
+    end
+  end
+end

--- a/lib/smartdown/api/state.rb
+++ b/lib/smartdown/api/state.rb
@@ -1,0 +1,58 @@
+require 'smartdown/api/previous_question'
+
+module Smartdown
+  module Api
+    class State
+
+      attr_reader :responses, :current_node
+
+      def initialize(current_node, previous_questionpage_smartdown_nodes, responses)
+        @current_node = current_node
+        @previous_question_page_nodes = previous_questionpage_smartdown_nodes
+        @responses = responses
+      end
+
+      def started?
+        !current_node.is_a? Smartdown::Api::Coversheet
+      end
+
+      def finished?
+        current_node.is_a? Smartdown::Api::Outcome
+      end
+
+      #TODO: refactor this :-O
+      def previous_questions
+        response_index = 0
+        previous_question_nodes.map.each_with_index do |previous_questions, node_index|
+          previous_questions.map.each_with_index do |previous_question, index|
+            previous_question = Smartdown::Api::PreviousQuestion.new(
+                previous_question_title_nodes[node_index][index].content,
+                previous_question,
+                responses[response_index],
+                index == 0
+            )
+            response_index+=1
+            previous_question
+          end
+        end.flatten
+      end
+
+      def previous_question_nodes
+        @previous_question_page_nodes.map(&:questions)
+      end
+
+      def previous_question_title_nodes
+        @previous_question_page_nodes.map(&:question_titles)
+      end
+
+      def current_question_number
+        responses.count + 1
+      end
+
+    private
+
+      attr_reader :smartdown_state, :previous_question_page_nodes
+
+    end
+  end
+end


### PR DESCRIPTION
Interaction between the smartdown gem and the smart-answers frontend application used to be part of the smart-answers application. This meant that concerns such as deducing whether we were on a question page, coversheet or outcome depending on the presence of specific nodes, or figuring out what the title for each question was from the markdown was done on the frontend side. 
This PR removes the code from the smart-answer application and moves it in the gem. 
