### PR TITLE
[do-not-merge] Multiple questions, date, salary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.1.1
+
+### Smartdown Adapter into gem under Api module
+
+This moves the logic to create and process smartdown flows into the gem away from the frontend application.
+
 ## 0.1.0
 
 ### Multiple questions per node

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.1.2
+
+### Date question, salary question
+
+Parses [date: identifier] and [salary: identifier].
+
 ## 0.1.1
 
 ### Smartdown Adapter into gem under Api module

--- a/README.md
+++ b/README.md
@@ -108,6 +108,22 @@ to your outbound flight.
 * no: No
 ```
 
+### Date
+
+```markdown
+## What is the baby’s due date?
+
+[date: baby_due_date]
+```
+
+### Salary
+
+```markdown
+## How much do you earn?
+
+[salary: salary_value]
+```
+
 ### Country (tbd)
 
 ```markdown
@@ -132,16 +148,6 @@ passport_country:
 [country: passport_country]
 ```
 
-### Date (tbd)
-
-```markdown
-## What is the baby’s due date?
-
-[date: baby_due_date]
-```
-
-Asks for a specific date in the given range. Ranges can be expressed as a relative number of years or absolute dates in YYYY-MM-DD format.
-
 ### Value (tbd)
 
 ```markdown
@@ -157,14 +163,6 @@ Asks for an arbitrary text input.
 ```
 
 Asks for a numerical input which can have decimals and optional thousand-separating commas.
-
-### Salary (tbd)
-
-```markdown
-[salary: salary_value]
-```
-
-Asks for salary which can be expressed as either a weekly or monthly money amount. The user chooses between weekly/monthly
 
 ### Checkbox (tbd)
 

--- a/lib/smartdown/api/date_question.rb
+++ b/lib/smartdown/api/date_question.rb
@@ -1,0 +1,35 @@
+require 'smartdown/api/question'
+
+module Smartdown
+  module Api
+    class DateQuestion < Question
+      def partial_template_name
+        "date_question"
+      end
+
+      def defaulted_day?
+        false
+      end
+
+      def defaulted_month?
+        false
+      end
+
+      def defaulted_year?
+        false
+      end
+
+      def default
+        Date.today
+      end
+
+      def start_date
+        Date.today - 365
+      end
+
+      def end_date
+        Date.today + 5*365
+      end
+    end
+  end
+end

--- a/lib/smartdown/api/flow.rb
+++ b/lib/smartdown/api/flow.rb
@@ -71,10 +71,10 @@ module Smartdown
         if node.elements.any?{|element| element.is_a? Smartdown::Model::Element::StartButton}
           Smartdown::Api::Coversheet.new(node)
         elsif node.elements.any?{|element| element.is_a? Smartdown::Model::NextNodeRules}
-          if node.elements.any?{|element| element.is_a? Smartdown::Model::Element::MultipleChoice}
+          if node.elements.any?{|element| element.class.to_s.include?("Smartdown::Model::Element::Question")}
             Smartdown::Api::QuestionPage.new(node)
           else
-            #TODO: support other types of questions
+            raise("Unknown node type: #{node.elements.map(&:class)}")
           end
         else
           Smartdown::Api::Outcome.new(node)

--- a/lib/smartdown/api/multiple_choice.rb
+++ b/lib/smartdown/api/multiple_choice.rb
@@ -4,14 +4,14 @@ module Smartdown
   module Api
     class MultipleChoice < Question
       def options
-        question = elements.find{|element| element.is_a? Smartdown::Model::Element::MultipleChoice}
+        question = elements.find{|element| element.is_a? Smartdown::Model::Element::Question::MultipleChoice}
         question.choices.map do |choice|
           OpenStruct.new(:label => choice[1], :value => choice[0])
         end
       end
 
       def name
-        question = elements.find{|element| element.is_a? Smartdown::Model::Element::MultipleChoice}
+        question = elements.find{|element| element.is_a? Smartdown::Model::Element::Question::MultipleChoice}
         question.name
       end
 

--- a/lib/smartdown/api/previous_question.rb
+++ b/lib/smartdown/api/previous_question.rb
@@ -23,7 +23,7 @@ module Smartdown
 
       #TODO: move to presenter, this object API should only expose question_element.choices
       def response_label(value=response)
-        @question_element.choices.fetch(value)
+        @question_element.response_label(value)
       end
 
     end

--- a/lib/smartdown/api/question_page.rb
+++ b/lib/smartdown/api/question_page.rb
@@ -1,4 +1,6 @@
 require 'smartdown/api/multiple_choice'
+require 'smartdown/api/date_question'
+require 'smartdown/api/salary'
 
 module Smartdown
   module Api
@@ -7,7 +9,13 @@ module Smartdown
         elements.slice_before do |element|
           element.is_a? Smartdown::Model::Element::MarkdownHeading
         end.each_with_index.map do |question_element_group, index|
-          Smartdown::Api::MultipleChoice.new(question_element_group, index+1)
+          if question_element_group.find{ |e| e.is_a? Smartdown::Model::Element::Question::MultipleChoice}
+            Smartdown::Api::MultipleChoice.new(question_element_group, index+1)
+          elsif question_element_group.find{ |e| e.is_a? Smartdown::Model::Element::Question::Date}
+            Smartdown::Api::DateQuestion.new(question_element_group, index+1)
+          elsif question_element_group.find{ |e| e.is_a? Smartdown::Model::Element::Question::Salary}
+            Smartdown::Api::Salary.new(question_element_group, index+1)
+          end
         end
       end
     end

--- a/lib/smartdown/api/salary.rb
+++ b/lib/smartdown/api/salary.rb
@@ -1,0 +1,11 @@
+require 'smartdown/api/question'
+
+module Smartdown
+  module Api
+    class Salary < Question
+      def partial_template_name
+        "salary_question"
+      end
+    end
+  end
+end

--- a/lib/smartdown/engine.rb
+++ b/lib/smartdown/engine.rb
@@ -31,7 +31,7 @@ module Smartdown
         nb_questions = 0
         current_node = flow.node(state.get(:current_node))
         nb_questions += current_node.elements.select{|element|
-          element.is_a? Smartdown::Model::Element::MultipleChoice
+          element.class.to_s.include?("Smartdown::Model::Element::Question")
         }.count
 
         #There is at least one relevant input per transition for now:

--- a/lib/smartdown/engine/transition.rb
+++ b/lib/smartdown/engine/transition.rb
@@ -38,7 +38,7 @@ module Smartdown
       end
 
       def input_variable_names_from_question
-        questions = node.elements.select { |e| e.is_a?(Smartdown::Model::Element::MultipleChoice) }
+        questions = node.elements.select { |e| e.class.to_s.include?("Smartdown::Model::Element::Question") }
         questions.map(&:name)
       end
 

--- a/lib/smartdown/model/element/multiple_choice.rb
+++ b/lib/smartdown/model/element/multiple_choice.rb
@@ -1,7 +1,0 @@
-module Smartdown
-  module Model
-    module Element
-      MultipleChoice = Struct.new(:name, :choices)
-    end
-  end
-end

--- a/lib/smartdown/model/element/question/date.rb
+++ b/lib/smartdown/model/element/question/date.rb
@@ -1,0 +1,13 @@
+module Smartdown
+  module Model
+    module Element
+      module Question
+        Date = Struct.new(:name) do
+          def response_label(value)
+            value
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/smartdown/model/element/question/multiple_choice.rb
+++ b/lib/smartdown/model/element/question/multiple_choice.rb
@@ -1,0 +1,13 @@
+module Smartdown
+  module Model
+    module Element
+      module Question
+        MultipleChoice = Struct.new(:name, :choices) do
+          def response_label(value)
+            choices.fetch(value)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/smartdown/model/element/question/salary.rb
+++ b/lib/smartdown/model/element/question/salary.rb
@@ -1,0 +1,13 @@
+module Smartdown
+  module Model
+    module Element
+      module Question
+        Salary = Struct.new(:name) do
+          def response_label(value)
+            value
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/smartdown/model/node.rb
+++ b/lib/smartdown/model/node.rb
@@ -8,7 +8,7 @@ module Smartdown
       end
 
       def questions
-        elements_of_kind(Smartdown::Model::Element::MultipleChoice)
+        elements.select{|e| e.class.to_s.include?("Smartdown::Model::Element::Question")}
       end
 
       #Because question titles and page titles use the same markdown,

--- a/lib/smartdown/parser/element/date_question.rb
+++ b/lib/smartdown/parser/element/date_question.rb
@@ -1,0 +1,22 @@
+require 'smartdown/parser/base'
+
+module Smartdown
+  module Parser
+    module Element
+      class DateQuestion < Base
+        rule(:date_question) {
+          (
+            str("[date:") >>
+            optional_space >>
+            question_identifier.as(:identifier) >>
+            optional_space >>
+            str("]") >>
+            optional_space >>
+            line_ending
+          ).as(:date)
+        }
+        root(:date_question)
+      end
+    end
+  end
+end

--- a/lib/smartdown/parser/element/salary_question.rb
+++ b/lib/smartdown/parser/element/salary_question.rb
@@ -1,0 +1,22 @@
+require 'smartdown/parser/base'
+
+module Smartdown
+  module Parser
+    module Element
+      class SalaryQuestion < Base
+        rule(:salary_question) {
+          (
+          str("[salary:") >>
+              optional_space >>
+              question_identifier.as(:identifier) >>
+              optional_space >>
+              str("]") >>
+              optional_space >>
+              line_ending
+          ).as(:salary)
+        }
+        root(:salary_question)
+      end
+    end
+  end
+end

--- a/lib/smartdown/parser/node_parser.rb
+++ b/lib/smartdown/parser/node_parser.rb
@@ -3,6 +3,8 @@ require 'smartdown/parser/rules'
 require 'smartdown/parser/element/front_matter'
 require 'smartdown/parser/element/start_button'
 require 'smartdown/parser/element/multiple_choice_question'
+require 'smartdown/parser/element/date_question'
+require 'smartdown/parser/element/salary_question'
 require 'smartdown/parser/element/markdown_heading'
 require 'smartdown/parser/element/markdown_paragraph'
 require 'smartdown/parser/element/conditional'
@@ -15,6 +17,8 @@ module Smartdown
         Element::Conditional.new |
         Element::MarkdownHeading.new |
         Element::MultipleChoiceQuestion.new |
+        Element::DateQuestion.new |
+        Element::SalaryQuestion.new |
         Rules.new |
         Element::StartButton.new |
         Element::NextSteps.new |

--- a/lib/smartdown/parser/node_transform.rb
+++ b/lib/smartdown/parser/node_transform.rb
@@ -4,7 +4,9 @@ require 'smartdown/model/front_matter'
 require 'smartdown/model/rule'
 require 'smartdown/model/nested_rule'
 require 'smartdown/model/next_node_rules'
-require 'smartdown/model/element/multiple_choice'
+require 'smartdown/model/element/question/multiple_choice'
+require 'smartdown/model/element/question/date'
+require 'smartdown/model/element/question/salary'
 require 'smartdown/model/element/start_button'
 require 'smartdown/model/element/markdown_heading'
 require 'smartdown/model/element/markdown_paragraph'
@@ -56,8 +58,20 @@ module Smartdown
       }
 
       rule(:multiple_choice => {identifier: simple(:identifier), options: subtree(:choices)}) {
-        Smartdown::Model::Element::MultipleChoice.new(
-          identifier, Hash[choices]
+        Smartdown::Model::Element::Question::MultipleChoice.new(
+          identifier.to_s, Hash[choices]
+        )
+      }
+
+      rule(:date => {identifier: simple(:identifier)}) {
+        Smartdown::Model::Element::Question::Date.new(
+          identifier.to_s
+        )
+      }
+
+      rule(:salary => {identifier: simple(:identifier)}) {
+        Smartdown::Model::Element::Question::Salary.new(
+          identifier.to_s
         )
       }
 

--- a/lib/smartdown/version.rb
+++ b/lib/smartdown/version.rb
@@ -1,3 +1,3 @@
 module Smartdown
-  VERSION = "0.1.0"
+  VERSION = "0.1.1"
 end

--- a/lib/smartdown/version.rb
+++ b/lib/smartdown/version.rb
@@ -1,3 +1,3 @@
 module Smartdown
-  VERSION = "0.1.1"
+  VERSION = "0.1.2"
 end

--- a/spec/acceptance/parsing_spec.rb
+++ b/spec/acceptance/parsing_spec.rb
@@ -88,7 +88,7 @@ EXPECTED
       end
 
       it "has a multiple choice question" do
-        expect(question_node.questions).to match([instance_of(Smartdown::Model::Element::MultipleChoice)])
+        expect(question_node.questions).to match([instance_of(Smartdown::Model::Element::Question::MultipleChoice)])
       end
     end
   end

--- a/spec/engine/transition_spec.rb
+++ b/spec/engine/transition_spec.rb
@@ -165,7 +165,7 @@ describe Smartdown::Engine::Transition do
       Smartdown::Model::Node.new(
         current_node_name,
         [
-          Smartdown::Model::Element::MultipleChoice.new(question_name, {"a" => "Apple"}),
+          Smartdown::Model::Element::Question::MultipleChoice.new(question_name, {"a" => "Apple"}),
           Smartdown::Model::NextNodeRules.new(
             [Smartdown::Model::Rule.new(double("predicate1"), "o1")]
           )

--- a/spec/parser/element/date_question_spec.rb
+++ b/spec/parser/element/date_question_spec.rb
@@ -1,0 +1,28 @@
+require 'smartdown/parser/node_parser'
+require 'smartdown/parser/node_interpreter'
+require 'smartdown/parser/element/date_question'
+
+describe Smartdown::Parser::Element::DateQuestion do
+  subject(:parser) { described_class.new }
+
+  context "with question tag" do
+    let(:source) { "[date: date_of_birth]" }
+
+    it "parses" do
+      should parse(source).as(
+        date: {
+          identifier: "date_of_birth",
+        }
+      )
+    end
+
+    describe "transformed" do
+      let(:node_name) { "my_node" }
+      subject(:transformed) {
+        Smartdown::Parser::NodeInterpreter.new(node_name, source, parser: parser).interpret
+      }
+
+      it { should eq(Smartdown::Model::Element::Question::Date.new("date_of_birth")) }
+    end
+  end
+end

--- a/spec/parser/element/multiple_choice_question_spec.rb
+++ b/spec/parser/element/multiple_choice_question_spec.rb
@@ -32,7 +32,7 @@ describe Smartdown::Parser::Element::MultipleChoiceQuestion do
         Smartdown::Parser::NodeInterpreter.new(node_name, source, parser: parser).interpret
       }
 
-      it { should eq(Smartdown::Model::Element::MultipleChoice.new("yes_or_no", {"yes"=>"Yes", "no"=>"No"})) }
+      it { should eq(Smartdown::Model::Element::Question::MultipleChoice.new("yes_or_no", {"yes"=>"Yes", "no"=>"No"})) }
     end
   end
 

--- a/spec/parser/element/salary_question_spec.rb
+++ b/spec/parser/element/salary_question_spec.rb
@@ -1,0 +1,28 @@
+require 'smartdown/parser/node_parser'
+require 'smartdown/parser/node_interpreter'
+require 'smartdown/parser/element/salary_question'
+
+describe Smartdown::Parser::Element::SalaryQuestion do
+  subject(:parser) { described_class.new }
+
+  context "with question tag" do
+    let(:source) { "[salary: mother_salary]" }
+
+    it "parses" do
+      should parse(source).as(
+        salary: {
+          identifier: "mother_salary",
+        }
+      )
+    end
+
+    describe "transformed" do
+      let(:node_name) { "my_node" }
+      subject(:transformed) {
+        Smartdown::Parser::NodeInterpreter.new(node_name, source, parser: parser).interpret
+      }
+
+      it { should eq(Smartdown::Model::Element::Question::Salary.new("mother_salary")) }
+    end
+  end
+end

--- a/spec/parser/node_parser_spec.rb
+++ b/spec/parser/node_parser_spec.rb
@@ -123,7 +123,7 @@ SOURCE
       let(:expected_elements) {
         [
           Smartdown::Model::Element::MarkdownHeading.new("This is my title"),
-          Smartdown::Model::Element::MultipleChoice.new("my_question", "yes"=>"Yes", "no"=>"No"),
+          Smartdown::Model::Element::Question::MultipleChoice.new("my_question", "yes"=>"Yes", "no"=>"No"),
           Smartdown::Model::Element::MarkdownHeading.new("Next node rules"),
           Smartdown::Model::NextNodeRules.new([
             Smartdown::Model::Rule.new(Smartdown::Model::Predicate::Named.new("pred1?"), "outcome")

--- a/spec/support/model_builder.rb
+++ b/spec/support/model_builder.rb
@@ -3,7 +3,8 @@ require 'smartdown/model/node'
 require 'smartdown/model/element/markdown_heading'
 require 'smartdown/model/element/markdown_paragraph'
 require 'smartdown/model/element/start_button'
-require 'smartdown/model/element/multiple_choice'
+require 'smartdown/model/element/question/multiple_choice'
+require 'smartdown/model/element/question/date'
 require 'smartdown/model/element/conditional'
 require 'smartdown/model/next_node_rules'
 require 'smartdown/model/rule'
@@ -48,7 +49,13 @@ class ModelBuilder
   def multiple_choice(name, options)
     @elements ||= []
     options_with_string_keys = ::Hash[options.map {|k,v| [k.to_s, v]}]
-    @elements << Smartdown::Model::Element::MultipleChoice.new(name, options_with_string_keys)
+    @elements << Smartdown::Model::Element::Question::MultipleChoice.new(name, options_with_string_keys)
+    @elements.last
+  end
+
+  def date(name)
+    @elements ||= []
+    @elements << Smartdown::Model::Element::Question::Date.new(name)
     @elements.last
   end
 

--- a/spec/support_specs/model_builder_spec.rb
+++ b/spec/support_specs/model_builder_spec.rb
@@ -15,7 +15,7 @@ describe ModelBuilder do
     let(:node2) {
       Smartdown::Model::Node.new("what_passport_do_you_have?", [
         Smartdown::Model::Element::MarkdownHeading.new("What passport do you have?"),
-        Smartdown::Model::Element::MultipleChoice.new("what_passport_do_you_have?", {"greek" => "Greek", "british" => "British"}),
+        Smartdown::Model::Element::Question::MultipleChoice.new("what_passport_do_you_have?", {"greek" => "Greek", "british" => "British"}),
         Smartdown::Model::NextNodeRules.new([
           Smartdown::Model::Rule.new(
             Smartdown::Model::Predicate::Named.new("eea_passport?"),


### PR DESCRIPTION
This pull requests adds the capability to parse `[date: identifier]` and `[salary: identifier]` as questions. 
This drove out additional work: before adding these questions, our only question type was "multiplechoice". Now we have multiple question types, several places in the code had to be changed to not check whether an element was a multiple choice, but rather checking if it was a question. 
