### PR TITLE
[merge FIRST] Predicate types: greater, lower, strictly greater, strictly lower

### DIFF
--- a/lib/smartdown/engine/predicate_evaluator.rb
+++ b/lib/smartdown/engine/predicate_evaluator.rb
@@ -14,6 +14,8 @@ module Smartdown
           ->(state) { predicate.values.include?(state.get(predicate.varname)) }
         when Smartdown::Model::Predicate::Named
           ->(state) { state.get(predicate.name) }
+        when Smartdown::Model::Predicate::Comparison::Base
+          ->(state) { predicate.evaluate(state.get(predicate.varname)) }
         else
           raise "Unknown predicate type #{predicate.class}"
         end

--- a/lib/smartdown/model/predicate/comparison/base.rb
+++ b/lib/smartdown/model/predicate/comparison/base.rb
@@ -1,0 +1,9 @@
+module Smartdown
+  module Model
+    module Predicate
+      module Comparison
+        Base = Struct.new(:varname, :value)
+      end
+    end
+  end
+end

--- a/lib/smartdown/model/predicate/comparison/greater.rb
+++ b/lib/smartdown/model/predicate/comparison/greater.rb
@@ -1,0 +1,15 @@
+require 'smartdown/model/predicate/comparison/base'
+
+module Smartdown
+  module Model
+    module Predicate
+      module Comparison
+        class Greater < Base
+          def evaluate(variable)
+            variable > value
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/smartdown/model/predicate/comparison/greater_or_equal.rb
+++ b/lib/smartdown/model/predicate/comparison/greater_or_equal.rb
@@ -1,0 +1,15 @@
+require 'smartdown/model/predicate/comparison/base'
+
+module Smartdown
+  module Model
+    module Predicate
+      module Comparison
+        class GreaterOrEqual < Base
+          def evaluate(variable)
+            variable >= value
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/smartdown/model/predicate/comparison/less.rb
+++ b/lib/smartdown/model/predicate/comparison/less.rb
@@ -1,0 +1,15 @@
+require 'smartdown/model/predicate/comparison/base'
+
+module Smartdown
+  module Model
+    module Predicate
+      module Comparison
+        class Less < Base
+          def evaluate(variable)
+            variable < value
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/smartdown/model/predicate/comparison/less_or_equal.rb
+++ b/lib/smartdown/model/predicate/comparison/less_or_equal.rb
@@ -1,0 +1,15 @@
+require 'smartdown/model/predicate/comparison/base'
+
+module Smartdown
+  module Model
+    module Predicate
+      module Comparison
+        class LessOrEqual < Base
+          def evaluate(variable)
+            variable <= value
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/smartdown/parser/node_transform.rb
+++ b/lib/smartdown/parser/node_transform.rb
@@ -15,6 +15,10 @@ require 'smartdown/model/element/next_steps'
 require 'smartdown/model/predicate/equality'
 require 'smartdown/model/predicate/set_membership'
 require 'smartdown/model/predicate/named'
+require 'smartdown/model/predicate/comparison/greater_or_equal'
+require 'smartdown/model/predicate/comparison/greater'
+require 'smartdown/model/predicate/comparison/less_or_equal'
+require 'smartdown/model/predicate/comparison/less'
 
 module Smartdown
   module Parser
@@ -112,6 +116,24 @@ module Smartdown
 
       rule(:named_predicate => simple(:name) ) {
         Smartdown::Model::Predicate::Named.new(name)
+      }
+
+      rule(:comparison_predicate => { varname: simple(:varname), 
+                                       value: simple(:value),
+                                       operator: simple(:operator)
+                                     }) { 
+        case operator
+        when "<="
+          Smartdown::Model::Predicate::Comparison::LessOrEqual.new(varname, value)
+        when "<"
+          Smartdown::Model::Predicate::Comparison::Less.new(varname, value)
+        when ">="
+          Smartdown::Model::Predicate::Comparison::GreaterOrEqual.new(varname, value)
+        when ">"
+          Smartdown::Model::Predicate::Comparison::Greater.new(varname, value)
+        else
+          raise "Comparison operator not recognised"
+        end
       }
 
       rule(:rule => {predicate: subtree(:predicate), outcome: simple(:outcome_name) } ) {

--- a/lib/smartdown/parser/predicates.rb
+++ b/lib/smartdown/parser/predicates.rb
@@ -9,6 +9,16 @@ module Smartdown
           str("'") >> match("[^']").repeat.as(:expected_value) >> str("'")
       }
 
+      rule(:comparison_operator) {
+        str('>=') | str('>') | str('<=') | str('<')
+      }
+
+      rule(:comparison_predicate) {
+        identifier.as(:varname) >> some_space >>
+        comparison_operator.as(:operator) >> some_space >>
+        str("'") >> match("[^']").repeat.as(:value) >> str("'")
+      }
+
       rule(:set_value) {
         match('[^\s}]').repeat(1).as(:set_value)
       }
@@ -26,8 +36,12 @@ module Smartdown
       rule(:named_predicate) {
         question_identifier.as(:named_predicate)
       }
+
       rule(:predicates) {
-        equality_predicate.as(:equality_predicate) | set_membership_predicate.as(:set_membership_predicate) | named_predicate
+        equality_predicate.as(:equality_predicate) |
+        set_membership_predicate.as(:set_membership_predicate) |
+        named_predicate |
+        comparison_predicate.as(:comparison_predicate)
       }
 
       root(:predicates)

--- a/spec/parser/predicates_spec.rb
+++ b/spec/parser/predicates_spec.rb
@@ -61,5 +61,42 @@ describe Smartdown::Parser::Predicates do
       it { should eq(Smartdown::Model::Predicate::Named.new("my_pred")) }
     end
   end
+
+  describe "comparison predicate" do
+    subject(:parser) { described_class.new }
+    let(:greater_equal_source) { "varname >= 'value'" }
+    let(:greater_source) { "varname > 'value'" }
+    let(:less_equal_source) { "varname <= 'value'" }
+    let(:less_source) { "varname < 'value'" }
+
+    it { should parse(greater_equal_source).as(comparison_predicate: {varname: "varname", value: "value", operator: ">="}) }
+    it { should_not parse("v >= value") }
+    it { should_not parse("v >= 'a thing's thing'") }
+    it { should_not parse("v >= 'a thing\\'s thing'") }
+    it { should_not parse(%q{v >= "a thing"}) }
+
+    describe "transformed" do
+      let(:node_name) { "my_node" }
+      subject(:transformed) {
+        Smartdown::Parser::NodeInterpreter.new(node_name, source, parser: parser).interpret
+      }
+      context "greater" do
+        let(:source) { greater_equal_source }
+        it { should eq(Smartdown::Model::Predicate::Comparison::GreaterOrEqual.new("varname", "value")) }
+      end
+      context "stricly greater" do
+        let(:source) { greater_source }
+        it { should eq(Smartdown::Model::Predicate::Comparison::Greater.new("varname", "value")) }
+      end
+      context "lower" do
+        let(:source) { less_equal_source }
+        it { should eq(Smartdown::Model::Predicate::Comparison::LessOrEqual.new("varname", "value")) }
+      end
+      context "strictly lower" do
+        let(:source) { less_source }
+        it { should eq(Smartdown::Model::Predicate::Comparison::Less.new("varname", "value")) }
+      end
+    end
+  end
 end
 

--- a/spec/support/model_builder.rb
+++ b/spec/support/model_builder.rb
@@ -11,6 +11,10 @@ require 'smartdown/model/rule'
 require 'smartdown/model/predicate/named'
 require 'smartdown/model/predicate/equality'
 require 'smartdown/model/predicate/set_membership'
+require 'smartdown/model/predicate/comparison/greater_or_equal'
+require 'smartdown/model/predicate/comparison/less_or_equal'
+require 'smartdown/model/predicate/comparison/greater'
+require 'smartdown/model/predicate/comparison/less'
 
 class ModelBuilder
   def flow(name, &block)


### PR DESCRIPTION
Support predicates of type
`age > 5`, `number_children <= 3`
For the moment this assumes that the variable can use the "usual" comparison operators "<=", ">", etc...
For more complex types, this will need to be iterated on. 
The four comparison types are implemented: "<=", "<", ">=", ">"
