### PR TITLE
Expose name on Smartdown::Api::Flow

### DIFF
--- a/lib/smartdown/api/flow.rb
+++ b/lib/smartdown/api/flow.rb
@@ -22,6 +22,10 @@ module Smartdown
         )
       end
 
+      def name
+        @smartdown_flow.name
+      end
+
       def title
         coversheet.title
       end


### PR DESCRIPTION
This will stop the Smart Answers app having to maintain the name itself, separately
from the flow object. Currently the app Flow presenter tracks name and looks up flow
and can't easily be refactored to just take flow.

When dealing with all flows in a registry, such as panopticon registration, there is
no programatic way to get the name from any gem output
