### PR TITLE
Make DirectoryInput part of the pubic API

### DIFF
--- a/lib/smartdown/api/directory_input.rb
+++ b/lib/smartdown/api/directory_input.rb
@@ -1,0 +1,11 @@
+require 'smartdown/parser/directory_input'
+
+module Smartdown
+  module Api
+    class DirectoryInput < Smartdown::Parser::DirectoryInput
+      def initialize(coversheet_path)
+        super(coversheet_path)
+      end
+    end
+  end
+end


### PR DESCRIPTION
As clients of the gem will need to call it, to then call Api::Flow, they shouldn't
have to call something in the Parser directory.

Moving the DirectoryInput module itself was a bit of a faff, so for now i've effectively
aliased it, so it's officially part of the public API, and the Smartdown internals can
be rearranged later.
