### PR TITLE
Improve separation of concerns for API

### DIFF
--- a/bin/smartdown
+++ b/bin/smartdown
@@ -17,7 +17,6 @@ if ARGV.size == 0
 else
   coversheet_path, *responses = ARGV
   begin
-    #TODO: use same object as smartdown-frontend will be using here
     input = Smartdown::Parser::DirectoryInput.new(coversheet_path)
     flow = Smartdown::Parser::FlowInterpreter.new(input).interpret
     engine = Smartdown::Engine.new(flow)

--- a/lib/smartdown/api/multiple_choice.rb
+++ b/lib/smartdown/api/multiple_choice.rb
@@ -15,11 +15,6 @@ module Smartdown
         question.name
       end
 
-      #TODO: move to presenters in smart-answer app
-      def partial_template_name
-        "multiple_choice_question"
-      end
-
     end
   end
 end

--- a/lib/smartdown/api/node.rb
+++ b/lib/smartdown/api/node.rb
@@ -6,31 +6,24 @@ module Smartdown
 
       def initialize(node)
         node_elements = node.elements.clone
-        headings = node_elements.select {
-            |element| element.is_a? Smartdown::Model::Element::MarkdownHeading
+        headings = node_elements.select { |element|
+          element.is_a? Smartdown::Model::Element::MarkdownHeading
         }
         @title = headings.first.content.to_s if headings.first
-        node_elements.delete(headings.first) #Remove page title
+        nb_questions = node_elements.select{ |element|
+          element.is_a? Smartdown::Model::Element::MultipleChoice
+        }.count
+        if headings.count > nb_questions
+          node_elements.delete(headings.first) #Remove page title
+        end
         @elements = node_elements
         @front_matter = node.front_matter
         @name = node.name
       end
 
-      def has_title?
-        !!title
-      end
-
       def body
         elements_before_smartdown = elements.take_while{|element| !smartdown_element?(element)}
         build_govspeak(elements_before_smartdown)
-      end
-
-      def has_body?
-        !!body
-      end
-
-      def has_devolved_body?
-        !!devolved_body
       end
 
       def devolved_body

--- a/lib/smartdown/api/outcome.rb
+++ b/lib/smartdown/api/outcome.rb
@@ -2,10 +2,6 @@ module Smartdown
   module Api
     class Outcome < Node
 
-      def has_next_steps?
-        !!next_steps
-      end
-
       def next_steps
         next_step_element = elements.find{|element| element.is_a? Smartdown::Model::Element::NextSteps}
         GovspeakPresenter.new(next_step_element.content).html if next_step_element

--- a/lib/smartdown/api/previous_question.rb
+++ b/lib/smartdown/api/previous_question.rb
@@ -1,29 +1,17 @@
 module Smartdown
   module Api
     class PreviousQuestion
+      extend Forwardable
 
-      attr_reader :response, :title
+      def_delegators :@question, :title, :options
 
-      def initialize(title, question_element, response, modifiable)
-        @title = title
-        @question_element = question_element
+      attr_reader :response
+
+      def initialize(elements, response)
         @response = response
-        @modifiable = modifiable
-      end
-
-      #TODO: remove need for this method by impleemnting modification properly
-      def modifiable?
-        @modifiable
-      end
-
-      #TODO: to be moved to presenter
-      def multiple_responses?
-        false
-      end
-
-      #TODO: move to presenter, this object API should only expose question_element.choices
-      def response_label(value=response)
-        @question_element.choices.fetch(value)
+        if elements.find{|element| element.is_a? Smartdown::Model::Element::MultipleChoice}
+          @question = MultipleChoice.new(elements)
+        end
       end
 
     end

--- a/lib/smartdown/api/previous_question_page.rb
+++ b/lib/smartdown/api/previous_question_page.rb
@@ -1,0 +1,38 @@
+require 'smartdown/api/previous_question'
+
+module Smartdown
+  module Api
+    class PreviousQuestionPage
+
+      attr_reader :title
+
+      def initialize(node, responses)
+        node_elements = node.elements.clone
+        headings = node_elements.select {
+          |element| element.is_a? Smartdown::Model::Element::MarkdownHeading
+        }
+        @title = headings.first.content.to_s if headings.first
+        nb_questions = node_elements.select{ |element|
+          element.is_a? Smartdown::Model::Element::MultipleChoice
+        }.count
+        if headings.count > nb_questions
+          node_elements.delete(headings.first) #Remove page title
+        end
+        @elements = node_elements
+        @responses = responses
+      end
+
+      def questions
+        elements.slice_before do |element|
+          element.is_a? Smartdown::Model::Element::MarkdownHeading
+        end.each_with_index.map do |question_element_group, index|
+          Smartdown::Api::PreviousQuestion.new(question_element_group, responses[index])
+        end
+      end
+
+      private
+
+      attr_reader :elements, :responses
+    end
+  end
+end

--- a/lib/smartdown/api/question.rb
+++ b/lib/smartdown/api/question.rb
@@ -2,20 +2,12 @@ module Smartdown
   module Api
     class Question
 
-      attr_reader :number
-
-      def initialize(elements, number=nil)
+      def initialize(elements)
         @elements = elements
-        @number = number
       end
 
-      #TODO: this assumes the title is the first element
       def title
         elements.first.content
-      end
-
-      def has_body?
-        !!body
       end
 
       def body
@@ -23,34 +15,8 @@ module Smartdown
         build_govspeak(elements_before_smartdown)
       end
 
-      def has_hint?
-        !!hint
-      end
-
-      #TODO: confirm we can delete this
-      # Usage TBC, most hints should actually be `body`s, semi-deprecated
-      # As we transition content we should better define it, or remove it
+      #TODO: deprecate
       def hint
-      end
-
-      def prefix
-        "todo prefix"
-      end
-
-      def suffix
-        "todo suffix"
-      end
-
-      def subtitle
-        "todo subtitle"
-      end
-
-      #TODO
-      def error
-      end
-
-      #TODO: should not be needed
-      def responses
       end
 
     private

--- a/lib/smartdown/api/question_page.rb
+++ b/lib/smartdown/api/question_page.rb
@@ -7,7 +7,7 @@ module Smartdown
         elements.slice_before do |element|
           element.is_a? Smartdown::Model::Element::MarkdownHeading
         end.each_with_index.map do |question_element_group, index|
-          Smartdown::Api::MultipleChoice.new(question_element_group, index+1)
+          Smartdown::Api::MultipleChoice.new(question_element_group)
         end
       end
     end

--- a/lib/smartdown/api/state.rb
+++ b/lib/smartdown/api/state.rb
@@ -1,4 +1,4 @@
-require 'smartdown/api/previous_question'
+require 'smartdown/api/previous_question_page'
 
 module Smartdown
   module Api
@@ -8,7 +8,7 @@ module Smartdown
 
       def initialize(current_node, previous_questionpage_smartdown_nodes, responses)
         @current_node = current_node
-        @previous_question_page_nodes = previous_questionpage_smartdown_nodes
+        @previous_questionpage_smartdown_nodes = previous_questionpage_smartdown_nodes
         @responses = responses
       end
 
@@ -20,29 +20,10 @@ module Smartdown
         current_node.is_a? Smartdown::Api::Outcome
       end
 
-      #TODO: refactor this :-O
-      def previous_questions
-        response_index = 0
-        previous_question_nodes.map.each_with_index do |previous_questions, node_index|
-          previous_questions.map.each_with_index do |previous_question, index|
-            previous_question = Smartdown::Api::PreviousQuestion.new(
-                previous_question_title_nodes[node_index][index].content,
-                previous_question,
-                responses[response_index],
-                index == 0
-            )
-            response_index+=1
-            previous_question
-          end
-        end.flatten
-      end
-
-      def previous_question_nodes
-        @previous_question_page_nodes.map(&:questions)
-      end
-
-      def previous_question_title_nodes
-        @previous_question_page_nodes.map(&:question_titles)
+      def previous_question_pages(responses)
+        previous_questionpage_smartdown_nodes.map do |smartdown_questionpage_node|
+          Smartdown::Api::PreviousQuestionPage.new(smartdown_questionpage_node, responses)
+        end
       end
 
       def current_question_number
@@ -51,7 +32,7 @@ module Smartdown
 
     private
 
-      attr_reader :smartdown_state, :previous_question_page_nodes
+      attr_reader :smartdown_state, :previous_questionpage_smartdown_nodes
 
     end
   end

--- a/lib/smartdown/model/node.rb
+++ b/lib/smartdown/model/node.rb
@@ -11,14 +11,6 @@ module Smartdown
         elements_of_kind(Smartdown::Model::Element::MultipleChoice)
       end
 
-      #Because question titles and page titles use the same markdown,
-      #there are at least as many or more headings than questions on each page
-      #To get only the question titles, we are assuming that all the headings that
-      #are not question headings come first in the markdown, then question headings
-      def question_titles
-        h1s.drop(h1s.count - questions.count)
-      end
-
       def title
         h1s.first ? h1s.first.content : ""
       end


### PR DESCRIPTION
Remove public methods from smartdown API objects which should live in presenters. 
