### PR TITLE
Expose coversheet node as part of public Flow API

### DIFF
--- a/lib/smartdown/api/flow.rb
+++ b/lib/smartdown/api/flow.rb
@@ -69,6 +69,10 @@ module Smartdown
         nodes.select{ |node| node.is_a? Smartdown::Api::Outcome}
       end
 
+      def coversheet
+        @coversheet ||= Smartdown::Api::Coversheet.new(@smartdown_flow.coversheet)
+      end
+
     private
 
       def transform_node(node)
@@ -83,10 +87,6 @@ module Smartdown
         else
           Smartdown::Api::Outcome.new(node)
         end
-      end
-
-      def coversheet
-        @coversheet ||= Smartdown::Api::Coversheet.new(@smartdown_flow.coversheet)
       end
 
       def front_matter


### PR DESCRIPTION
Previously this was private, but it's useful to some clients, see:
- https://github.com/alphagov/smart-answers/blob/master/lib/smartdown_adapter/flow_registration_presenter.rb#L44

Also we expose questions, question pages and outcomes, so we should
do the same for covers.
