### PR TITLE
Engine & Flow can take additional 'default' states

### DIFF
--- a/lib/smartdown/api/flow.rb
+++ b/lib/smartdown/api/flow.rb
@@ -8,10 +8,9 @@ require 'smartdown/api/outcome'
 module Smartdown
   module Api
     class Flow
-
-      def initialize(smartdown_input)
+      def initialize(smartdown_input, initial_state = {})
         @smartdown_flow = Smartdown::Parser::FlowInterpreter.new(smartdown_input).interpret
-        @engine = Smartdown::Engine.new(@smartdown_flow)
+        @engine = Smartdown::Engine.new(@smartdown_flow, initial_state)
       end
 
       def state(started, responses)

--- a/lib/smartdown/engine.rb
+++ b/lib/smartdown/engine.rb
@@ -6,11 +6,12 @@ module Smartdown
   class Engine
     attr_reader :flow
 
-    def initialize(flow)
+    def initialize(flow, initial_state = {})
       @flow = flow
+      @initial_state = initial_state
     end
 
-    def default_start_state
+    def build_start_state
       Smartdown::Engine::State.new(
         default_predicates.merge(
           current_node: flow.name
@@ -21,11 +22,11 @@ module Smartdown
     def default_predicates
       {
         otherwise: ->(_) { true }
-      }
+      }.merge(@initial_state)
     end
 
-    def process(responses, start_state = nil)
-      state = start_state || default_start_state
+    def process(responses, test_start_state = nil)
+      state = test_start_state || build_start_state
       unprocessed_responses = responses
       while !unprocessed_responses.empty? do
         nb_questions = 0

--- a/spec/engine_spec.rb
+++ b/spec/engine_spec.rb
@@ -4,7 +4,7 @@ describe Smartdown::Engine do
 
   subject(:engine) { Smartdown::Engine.new(flow) }
   let(:start_state) {
-    engine.default_start_state
+    engine.build_start_state
       .put(:eea_passport?, ->(state) {
         %w{greek british}.include?(state.get(:what_passport_do_you_have?))
       })
@@ -116,6 +116,20 @@ describe Smartdown::Engine do
       end
     end
   }
+
+  describe "initial_state" do
+    let(:initial_state) { {
+      key_1: 'a_state_object',
+      key_2: ->(state) { 'a_dynamic_state_object' }
+    } }
+    let(:engine) { Smartdown::Engine.new(flow, initial_state) }
+    subject(:state) { engine.process([]) }
+
+    it "should have added initial_state to state" do
+      expect(subject.get(:key_1)).to eql 'a_state_object'
+      expect(subject.get(:key_2)).to eql 'a_dynamic_state_object'
+    end
+  end
 
   describe "#process" do
     subject { engine.process(responses, start_state) }


### PR DESCRIPTION
This enables plugins to be passed in by client applications.
