### PR TITLE
Let predicates self describe in a human form

### DIFF
--- a/lib/smartdown/model/predicate/combined.rb
+++ b/lib/smartdown/model/predicate/combined.rb
@@ -3,7 +3,11 @@ module Smartdown
     module Predicate
       Combined = Struct.new(:predicates) do
         def evaluate(state)
-            predicates.map { |predicate| predicate.evaluate(state) }.all?
+          predicates.map { |predicate| predicate.evaluate(state) }.all?
+        end
+
+        def humanize
+          "(#{predicates.map { |p| p.humanize }.join(' AND ')})"
         end
       end
     end

--- a/lib/smartdown/model/predicate/comparison/greater.rb
+++ b/lib/smartdown/model/predicate/comparison/greater.rb
@@ -14,6 +14,10 @@ module Smartdown
               variable > value
             end
           end
+
+          def humanize
+            "#{varname} > #{value}"
+          end
         end
       end
     end

--- a/lib/smartdown/model/predicate/comparison/greater_or_equal.rb
+++ b/lib/smartdown/model/predicate/comparison/greater_or_equal.rb
@@ -14,6 +14,10 @@ module Smartdown
               variable >= value
             end
           end
+
+          def humanize
+            "#{varname} >= #{value}"
+          end
         end
       end
     end

--- a/lib/smartdown/model/predicate/comparison/less.rb
+++ b/lib/smartdown/model/predicate/comparison/less.rb
@@ -14,6 +14,10 @@ module Smartdown
               variable < value
             end
           end
+
+          def humanize
+            "#{varname} < #{value}"
+          end
         end
       end
     end

--- a/lib/smartdown/model/predicate/comparison/less_or_equal.rb
+++ b/lib/smartdown/model/predicate/comparison/less_or_equal.rb
@@ -14,6 +14,10 @@ module Smartdown
               variable <= value
             end
           end
+
+          def humanize
+            "#{varname} <= #{value}"
+          end
         end
       end
     end

--- a/lib/smartdown/model/predicate/equality.rb
+++ b/lib/smartdown/model/predicate/equality.rb
@@ -3,7 +3,11 @@ module Smartdown
     module Predicate
       Equality = Struct.new(:varname, :expected_value) do
         def evaluate(state)
-            state.get(varname) == expected_value
+          state.get(varname) == expected_value
+        end
+
+        def humanize
+          "#{varname} == '#{expected_value}'"
         end
       end
     end

--- a/lib/smartdown/model/predicate/named.rb
+++ b/lib/smartdown/model/predicate/named.rb
@@ -3,7 +3,11 @@ module Smartdown
     module Predicate
       Named = Struct.new(:name) do
         def evaluate(state)
-            state.get(name)
+          state.get(name)
+        end
+
+        def humanize
+          "#{name.to_s.chomp('?')}?"
         end
       end
     end

--- a/lib/smartdown/model/predicate/set_membership.rb
+++ b/lib/smartdown/model/predicate/set_membership.rb
@@ -3,7 +3,11 @@ module Smartdown
     module Predicate
       SetMembership = Struct.new(:varname, :values) do
         def evaluate(state)
-            values.include?(state.get(varname))
+          values.include?(state.get(varname))
+        end
+
+        def humanize
+          "#{varname} in [#{values.join(", ")}]"
         end
       end
     end

--- a/spec/model/predicates/combined_spec.rb
+++ b/spec/model/predicates/combined_spec.rb
@@ -40,4 +40,8 @@ describe Smartdown::Model::Predicate::Combined do
       end
     end
   end
+
+  describe "#humanize" do
+    it { expect(predicate.humanize).to eq("(my_pred? AND my_other_pred?)") }
+  end
 end

--- a/spec/model/predicates/comparison_spec.rb
+++ b/spec/model/predicates/comparison_spec.rb
@@ -73,6 +73,21 @@ describe "comparison predicates" do
         end
       end
     end
+
+    describe "#humanize" do
+      let(:results) { {
+        :greater => "my_var > 5",
+        :greater_or_equal => "my_var >= 5",
+        :less => "my_var < 5",
+        :less_or_equal => "my_var <= 5"
+      } }
+
+      it "has the right human representation" do
+        predicates.each do |predicate_key, predicate|
+          expect(predicate.humanize).to eq(results[predicate_key])
+        end
+      end
+    end
   end
 
   context "comparison predicates with dates" do

--- a/spec/model/predicates/equality_spec.rb
+++ b/spec/model/predicates/equality_spec.rb
@@ -29,4 +29,8 @@ describe Smartdown::Model::Predicate::Equality do
       end
     end
   end
+
+  describe "#humanize" do
+    it { expect(predicate.humanize).to eq("my_var == 'some value'") }
+  end
 end

--- a/spec/model/predicates/named_spec.rb
+++ b/spec/model/predicates/named_spec.rb
@@ -24,4 +24,18 @@ describe Smartdown::Model::Predicate::Named do
       end
     end
   end
+
+  describe "#humanize" do
+    context "predicate name without question mark" do
+      subject(:predicate) { described_class.new("my_pred") }
+
+      it { expect(predicate.humanize).to eq("my_pred?") }
+    end
+
+    context "predicate name with question mark" do
+      subject(:predicate) { described_class.new("my_pred?") }
+
+      it { expect(predicate.humanize).to eq("my_pred?") }
+    end
+  end
 end

--- a/spec/model/predicates/set_membership_spec.rb
+++ b/spec/model/predicates/set_membership_spec.rb
@@ -32,4 +32,8 @@ describe Smartdown::Model::Predicate::SetMembership do
       end
     end
   end
+
+  describe "#humanize" do
+    it { expect(predicate.humanize).to eq("my_var in [v1, v2, v3]") }
+  end
 end

--- a/spec/parser/predicates_spec.rb
+++ b/spec/parser/predicates_spec.rb
@@ -122,19 +122,19 @@ describe Smartdown::Parser::Predicates do
       subject(:transformed) {
         Smartdown::Parser::NodeInterpreter.new(node_name, source, parser: parser).interpret
       }
-      context "greater" do
+      context "greater or equal" do
         let(:source) { greater_equal_source }
         it { should eq(Smartdown::Model::Predicate::Comparison::GreaterOrEqual.new("varname", "value")) }
       end
-      context "stricly greater" do
+      context "greater" do
         let(:source) { greater_source }
         it { should eq(Smartdown::Model::Predicate::Comparison::Greater.new("varname", "value")) }
       end
-      context "lower" do
+      context "less than or equal" do
         let(:source) { less_equal_source }
         it { should eq(Smartdown::Model::Predicate::Comparison::LessOrEqual.new("varname", "value")) }
       end
-      context "strictly lower" do
+      context "less than" do
         let(:source) { less_source }
         it { should eq(Smartdown::Model::Predicate::Comparison::Less.new("varname", "value")) }
       end


### PR DESCRIPTION
Useful for debugging, and can be used in graph visualisations.

Currently graph visualisation has to know about each kind predicate
(and it's internal implementation) to create a human readable version representation.

This puts that responsibility into the predicate itself.
