### PR TITLE
Function predicates

### DIFF
--- a/lib/smartdown/engine.rb
+++ b/lib/smartdown/engine.rb
@@ -1,6 +1,7 @@
 require 'smartdown/engine/transition'
 require 'smartdown/engine/state'
 require 'smartdown/engine/node_presenter'
+require 'smartdown/model/predicate/otherwise'
 
 module Smartdown
   class Engine
@@ -21,7 +22,7 @@ module Smartdown
 
     def default_predicates
       {
-        otherwise: ->(_) { true }
+        otherwise: Smartdown::Model::Predicate::Otherwise.new
       }.merge(@initial_state)
     end
 

--- a/lib/smartdown/engine/state.rb
+++ b/lib/smartdown/engine/state.rb
@@ -21,9 +21,9 @@ module Smartdown
         has_key?(key) && fetch(key) == expected_value
       end
 
-      def get(key)
+      def get(key, with_eval= true)
         value = fetch(key)
-        if value.respond_to?(:call)
+        if value.respond_to?(:call) and with_eval
           evaluate(value)
         else
           value

--- a/lib/smartdown/engine/state.rb
+++ b/lib/smartdown/engine/state.rb
@@ -21,13 +21,8 @@ module Smartdown
         has_key?(key) && fetch(key) == expected_value
       end
 
-      def get(key, with_eval= true)
-        value = fetch(key)
-        if value.respond_to?(:call) and with_eval
-          evaluate(value)
-        else
-          value
-        end
+      def get(key)
+        fetch(key)
       end
 
       def put(name, value)
@@ -53,10 +48,6 @@ module Smartdown
         else
           raise UndefinedValue, "variable '#{key}' not defined", caller
         end
-      end
-
-      def evaluate(callable)
-        @cached[callable] ||= callable.call(self)
       end
     end
   end

--- a/lib/smartdown/model/predicate/function.rb
+++ b/lib/smartdown/model/predicate/function.rb
@@ -1,0 +1,28 @@
+module Smartdown
+  module Model
+    module Predicate
+      Function = Struct.new(:name, :arguments) do
+        def evaluate(state)
+          state.get(name, false).call(*evaluate_arguments(state))
+        end
+
+        def humanize
+          "#{name}(#{arguments.join(' ')})"
+        end
+
+      private
+
+        def evaluate_arguments(state)
+          # Should have an evaluatable "variable" object that matches identifier
+          arguments.map do |argument|
+            if argument.respond_to?(:evaluate)
+              argument.evaluate(state)
+            else
+              state.get(argument)
+            end
+         end
+        end
+      end
+    end
+  end
+end

--- a/lib/smartdown/model/predicate/function.rb
+++ b/lib/smartdown/model/predicate/function.rb
@@ -3,7 +3,7 @@ module Smartdown
     module Predicate
       Function = Struct.new(:name, :arguments) do
         def evaluate(state)
-          state.get(name, false).call(*evaluate_arguments(state))
+          state.get(name).call(*evaluate_arguments(state))
         end
 
         def humanize

--- a/lib/smartdown/model/predicate/named.rb
+++ b/lib/smartdown/model/predicate/named.rb
@@ -3,7 +3,7 @@ module Smartdown
     module Predicate
       Named = Struct.new(:name) do
         def evaluate(state)
-          state.get(name)
+          !!state.get(name)
         end
 
         def humanize

--- a/lib/smartdown/model/predicate/otherwise.rb
+++ b/lib/smartdown/model/predicate/otherwise.rb
@@ -1,0 +1,11 @@
+module Smartdown
+  module Model
+    module Predicate
+      class Otherwise
+        def evaluate(state)
+            true
+        end
+      end
+    end
+  end
+end

--- a/lib/smartdown/parser/node_transform.rb
+++ b/lib/smartdown/parser/node_transform.rb
@@ -16,6 +16,7 @@ require 'smartdown/model/predicate/equality'
 require 'smartdown/model/predicate/set_membership'
 require 'smartdown/model/predicate/named'
 require 'smartdown/model/predicate/combined'
+require 'smartdown/model/predicate/function'
 require 'smartdown/model/predicate/comparison/greater_or_equal'
 require 'smartdown/model/predicate/comparison/greater'
 require 'smartdown/model/predicate/comparison/less_or_equal'
@@ -123,6 +124,16 @@ module Smartdown
 
       rule(:combined_predicate => {first_predicate: subtree(:first_predicate), and_predicates: subtree(:and_predicates) }) {
         Smartdown::Model::Predicate::Combined.new([first_predicate]+and_predicates)
+      }
+
+      rule(:function_argument => simple(:argument)) { argument }
+
+      rule(:function_predicate => { name: simple(:name), arguments: subtree(:arguments) }) {
+        Smartdown::Model::Predicate::Function.new(name, Array(arguments))
+      }
+
+      rule(:function_predicate => { name: simple(:name) }) {
+        Smartdown::Model::Predicate::Function.new(name, [])
       }
 
       rule(:comparison_predicate => { varname: simple(:varname), 

--- a/lib/smartdown/parser/predicates.rb
+++ b/lib/smartdown/parser/predicates.rb
@@ -50,8 +50,20 @@ module Smartdown
         predicate).repeat(1).as(:and_predicates)
       }
 
+      rule(:function_arguments) {
+        identifier.as(:function_argument) >> (some_space >> identifier.as(:function_argument)).repeat
+      }
+
+      rule (:function_predicate) {
+        identifier.as(:name) >>
+        str('(') >>
+        function_arguments.as(:arguments).maybe >>
+        str(')')
+      }
+
       rule (:predicates) {
         combined_predicate.as(:combined_predicate) |
+        function_predicate.as(:function_predicate) |
         predicate
       }
 

--- a/spec/engine/state_spec.rb
+++ b/spec/engine/state_spec.rb
@@ -48,43 +48,6 @@ describe Smartdown::Engine::State do
     end
   end
 
-  context "lambda values" do
-    let(:predicate) { double("predicate", call: true) }
-    subject(:state) {
-      described_class.new(current_node: :start_state, predicate?: predicate)
-    }
-
-    describe "#get" do
-      it "evaluates lambda with state" do
-        expect(predicate).to receive(:call).with(state).and_return(true)
-        expect(state.get(:predicate?)).to eq(true)
-      end
-
-      it "caches the result of evaluating the lambda" do
-        expect(predicate).to receive(:call).once
-        state.get(:predicate?)
-        state.get(:predicate?)
-      end
-    end
-
-    describe "#==" do
-      let(:l1) { ->(state) { true } }
-      let(:l2) { ->(state) { true } }
-
-      let(:state_with_l1a) { described_class.new(current_node: "red", pred: l1)}
-      let(:state_with_l1b) { described_class.new(current_node: "red", pred: l1)}
-      let(:state_with_l2) { described_class.new(current_node: "red", pred: l2)}
-
-      it "is equal if identical lambdas" do
-        expect(state_with_l1a).to eq(state_with_l1b)
-      end
-
-      it "is not equal if different lambdas" do
-        expect(state_with_l1a).not_to eq(state_with_l2)
-      end
-    end
-  end
-
   describe "#==" do
     let(:s1) { described_class.new(current_node: "red") }
     let(:s2) { described_class.new(current_node: "red") }

--- a/spec/engine_spec.rb
+++ b/spec/engine_spec.rb
@@ -5,12 +5,6 @@ describe Smartdown::Engine do
   subject(:engine) { Smartdown::Engine.new(flow) }
   let(:start_state) {
     engine.build_start_state
-      .put(:eea_passport?, ->(state) {
-        %w{greek british}.include?(state.get(:what_passport_do_you_have?))
-      })
-      .put(:imaginary?, ->(state) {
-        %w{narnia}.include?(state.get(:what_country_are_you_going_to?))
-      })
       .put(:otherwise, true)
   }
 
@@ -34,7 +28,7 @@ describe Smartdown::Engine do
         )
         next_node_rules do
           rule do
-            named_predicate("eea_passport?")
+            set_membership_predicate("what_passport_do_you_have?", ["greek", "british"])
             outcome("outcome_no_visa_needed")
           end
         end
@@ -85,11 +79,11 @@ describe Smartdown::Engine do
         )
         next_node_rules do
           rule do
-            named_predicate("imaginary?")
+            set_membership_predicate("what_country_are_you_going_to?", ["narnia"])
             outcome("outcome_imaginary_country")
           end
           rule do
-            named_predicate("eea_passport?")
+            set_membership_predicate("what_passport_do_you_have?", ["greek", "british"])
             outcome("outcome_no_visa_needed")
           end
         end
@@ -118,16 +112,19 @@ describe Smartdown::Engine do
   }
 
   describe "initial_state" do
+    let(:lambda) {
+      ->(state) { 'a_dynamic_state_object' }
+    }
     let(:initial_state) { {
       key_1: 'a_state_object',
-      key_2: ->(state) { 'a_dynamic_state_object' }
+      key_2: :lambda
     } }
     let(:engine) { Smartdown::Engine.new(flow, initial_state) }
     subject(:state) { engine.process([]) }
 
     it "should have added initial_state to state" do
       expect(subject.get(:key_1)).to eql 'a_state_object'
-      expect(subject.get(:key_2)).to eql 'a_dynamic_state_object'
+      expect(subject.get(:key_2)).to eql :lambda
     end
   end
 

--- a/spec/model/predicates/function_spec.rb
+++ b/spec/model/predicates/function_spec.rb
@@ -1,0 +1,85 @@
+require 'smartdown/model/predicate/function'
+require 'smartdown/engine/state'
+
+describe Smartdown::Model::Predicate::Function do
+  let(:function_name) { "my_function" }
+  subject(:predicate) { described_class.new(function_name, []) }
+
+  describe "#evaluate" do
+    context "state missing expected function definition" do
+      let(:state) { Smartdown::Engine::State.new(current_node: "n") }
+
+      it "raises an UndefinedValue error" do
+        expect { predicate.evaluate(state) }.to raise_error(Smartdown::Engine::UndefinedValue)
+      end
+    end
+
+    context "with no arguments" do
+      let(:function_return) { "hello" }
+      let(:my_function) { ->() { "hello" } }
+      let(:state) { Smartdown::Engine::State.new(current_node: "n", function_name => my_function) }
+
+      it "gets the return value of the function" do
+        expect(predicate.evaluate(state)).to eq(function_return)
+      end
+    end
+
+    context "with arguments" do
+      let(:my_function) { ->(x) { x * 100 } }
+      subject(:predicate) { described_class.new(function_name, ["number"]) }
+      let(:state) { Smartdown::Engine::State.new(current_node: "n", "number" => 3, function_name => my_function) }
+
+      it "gets the return value of the function" do
+        expect(predicate.evaluate(state)).to eq(300)
+      end
+    end
+
+    context "with many arguments" do
+      let(:function_return) { "hello" }
+      let(:my_function) { ->(name, age) { "Hi #{name}, you were #{age-20}, 20 years ago" } }
+      subject(:predicate) { described_class.new(function_name, ["name", "age"]) }
+      let(:state) { Smartdown::Engine::State.new(current_node: "n", "name" => "David", "age" => 30, function_name => my_function) }
+
+      it "gets the return value of the function" do
+        expect(predicate.evaluate(state)).to eq("Hi David, you were 10, 20 years ago")
+      end
+    end
+
+    context "with nested functions" do
+      # nesting looks like: function_1(function_2(5))
+      let(:function_1) { ->(x) { x - 1 } }
+      let(:function_2) { ->(x) { x * 100 } }
+      subject(:predicate) {
+        described_class.new("function_1", [
+          described_class.new("function_2", ['number'])
+        ])
+      }
+
+      let(:state) { Smartdown::Engine::State.new(
+        current_node: "n",
+        "function_1" => function_1,
+        "function_2" => function_2,
+        "number" => 5
+      ) }
+
+      it "gets the return value of the function" do
+        expect(predicate.evaluate(state)).to eq(499)
+      end
+    end
+  end
+
+  describe "#humanize" do
+    context "with no arguments" do
+      subject(:predicate) { described_class.new(function_name, []) }
+
+      it { expect(predicate.humanize).to eq("my_function()") }
+    end
+
+    context "with some arguments" do
+      let(:function_name) { "my_function" }
+      subject(:predicate) { described_class.new(function_name, ['foo', 'bar']) }
+
+      it { expect(predicate.humanize).to eq("my_function(foo bar)") }
+    end
+  end
+end

--- a/spec/support/model_builder.rb
+++ b/spec/support/model_builder.rb
@@ -120,6 +120,10 @@ class ModelBuilder
     @predicate = Smartdown::Model::Predicate::Named.new(name)
   end
 
+  def set_membership_predicate(varname, values)
+    @predicate = Smartdown::Model::Predicate::SetMembership.new(varname, values)
+  end
+
   def outcome(name)
     @outcome = name
   end


### PR DESCRIPTION
Adds support for calling a function with arguments, these arguments can even be evaluatable themselves, eg, another function, the result of a predicate.

A contrived example would look like this:

```
calculate_holiday_pay(days_worked, calculate_salary(monthly_salary)
```

Where:
- `calculate_holiday_pay` is a function, this would be injected in the Smartdown Engine scope by the calling application
- `days_worked` is an answer to a question that the user has answered, eg, 12
- `calculate_salary` is another injected function, that takes it's own argument, calculates its answer, which is evaluated by `calculate_holiday_pay`

Predicate is a really bad name for this, but it's consistent with the naming and structure of the existing code and I didn't want to change it for just one thing. It's something that should be looked at in the future.

The specs do quite a good job of showing how they're used:
- Parsing: https://github.com/alphagov/smartdown/blob/ad214a3a55aff3921012c8ea24d8ff2af556cf5d/spec/parser/predicates_spec.rb
- Evaluation: https://github.com/alphagov/smartdown/blob/ff83ecc41d95eb84f1fcbdf54a1d5b39695d01d1/spec/model/predicates/function_spec.rb

The functions will be evaluated in next node rules/predicates and within conditions, but not yet for interpolations. That's coming in https://github.com/alphagov/smartdown/tree/complex-interpolation
