### PR TITLE
[Merge after #53] Parsed interpolation values

### DIFF
--- a/lib/smartdown/engine/interpolator.rb
+++ b/lib/smartdown/engine/interpolator.rb
@@ -39,7 +39,18 @@ module Smartdown
 
       private
         def interpolate(text, state)
-          text.to_s.gsub(/%{([^}]+)}/) { |_| state.get($1) }
+          text.to_s.gsub(/%{([^}]+)}/) do |_|
+            resolve_term($1, state)
+          end
+        end
+
+        def resolve_term(interpolation, state)
+          begin
+              parsed = Smartdown::Parser::Predicates.new.parse(interpolation)
+              Smartdown::Parser::NodeTransform.new.apply(parsed, {}).evaluate(state)
+            rescue Parslet::ParseFailed
+              state.get(interpolation)
+            end
         end
       end
 

--- a/lib/smartdown/model/predicate/named.rb
+++ b/lib/smartdown/model/predicate/named.rb
@@ -3,7 +3,7 @@ module Smartdown
     module Predicate
       Named = Struct.new(:name) do
         def evaluate(state)
-          state.get(name)
+          !!state.get(name)
         end
 
         def humanize

--- a/lib/smartdown/model/predicate/named.rb
+++ b/lib/smartdown/model/predicate/named.rb
@@ -3,7 +3,7 @@ module Smartdown
     module Predicate
       Named = Struct.new(:name) do
         def evaluate(state)
-          !!state.get(name)
+          state.get(name)
         end
 
         def humanize

--- a/lib/smartdown/parser/predicates.rb
+++ b/lib/smartdown/parser/predicates.rb
@@ -34,7 +34,7 @@ module Smartdown
       }
 
       rule(:named_predicate) {
-        question_identifier.as(:named_predicate)
+        (identifier >> str('?')).as(:named_predicate)
       }
 
       rule(:predicate) {

--- a/spec/engine/interpolator_spec.rb
+++ b/spec/engine/interpolator_spec.rb
@@ -78,4 +78,18 @@ describe Smartdown::Engine::Interpolator do
       expect(interpolated_node.elements.first.content).to eq("Hello #{example_name}")
     end
   end
+
+  context "a paragraph containing function call" do
+    let(:elements) { [Smartdown::Model::Element::MarkdownParagraph.new('%{double(number)}')] }
+    let(:state) {
+      Smartdown::Engine::State.new(
+        current_node: node.name,
+        number: 10,
+        double: ->(number) { number * 2 }
+      )
+    }
+    it "interpolates the result of the function call" do
+      expect(interpolated_node.elements.first.content).to eq("20")
+    end
+  end
 end

--- a/spec/parser/predicates_spec.rb
+++ b/spec/parser/predicates_spec.rb
@@ -47,39 +47,39 @@ describe Smartdown::Parser::Predicates do
   describe "named predicate" do
     subject(:parser) { described_class.new }
 
-    it { should parse("my_pred").as(named_predicate: "my_pred") }
     it { should parse("my_pred?").as(named_predicate: "my_pred?") }
+    it { should_not parse("my_pred") }
     it { should_not parse("my pred") }
 
     describe "transformed" do
       let(:node_name) { "my_node" }
-      let(:source) { "my_pred" }
+      let(:source) { "my_pred?" }
       subject(:transformed) {
         Smartdown::Parser::NodeInterpreter.new(node_name, source, parser: parser).interpret
       }
 
-      it { should eq(Smartdown::Model::Predicate::Named.new("my_pred")) }
+      it { should eq(Smartdown::Model::Predicate::Named.new("my_pred?")) }
     end
   end
 
   describe "predicate AND predicate" do
     subject(:parser) { described_class.new }
 
-    it { should parse("my_pred AND my_other_pred").as(
+    it { should parse("my_pred? AND my_other_pred?").as(
       { combined_predicate: {
-        first_predicate: { named_predicate: "my_pred" },
+        first_predicate: { named_predicate: "my_pred?" },
         and_predicates:
           [
-            {named_predicate: "my_other_pred"},
+            {named_predicate: "my_other_pred?"},
           ]
       } }
     ) }
-    it { should parse("my_pred AND my_other_pred AND varname in {a b c}").as(
+    it { should parse("my_pred? AND my_other_pred? AND varname in {a b c}").as(
       { combined_predicate: {
-        first_predicate: { named_predicate: "my_pred" },
+        first_predicate: { named_predicate: "my_pred?" },
         and_predicates:
           [
-            {named_predicate: "my_other_pred"},
+            {named_predicate: "my_other_pred?"},
             {set_membership_predicate:
               {varname: "varname", values: [{set_value: "a"}, {set_value: "b"}, {set_value: "c"}]}
             }
@@ -90,15 +90,15 @@ describe Smartdown::Parser::Predicates do
 
     describe "transformed" do
       let(:node_name) { "my_node" }
-      let(:source) { "my_pred AND my_other_pred" }
+      let(:source) { "my_pred? AND my_other_pred?" }
       subject(:transformed) {
         Smartdown::Parser::NodeInterpreter.new(node_name, source, parser: parser).interpret
       }
 
       it { should eq(Smartdown::Model::Predicate::Combined.new(
         [
-          Smartdown::Model::Predicate::Named.new("my_pred"),
-          Smartdown::Model::Predicate::Named.new("my_other_pred")
+          Smartdown::Model::Predicate::Named.new("my_pred?"),
+          Smartdown::Model::Predicate::Named.new("my_other_pred?")
         ]
       )) }
     end


### PR DESCRIPTION
Blocked by Functions branch: https://github.com/alphagov/smartdown/pull/53

This re-uses parsing/transform in interpolation, so it uses the same logic/code as functions/values/predicates in next node rules and conditionals.

This allows it to support function calls in interpolation, and any new parsable/evaluatable features added in the future should Just Work™ for interpolation as well.

To do this I had to update the parsing rules for named predicates, making a trailing `?` required, otherwise it would parse pretty much everything as a named predicate. IMO this is a more readable convention anyway, but this may be a breaking change for some existing Smartdown flows that don't use the trailing `?` pattern. We should note it in release notes and version bump accordingly. 
