### PR TITLE
Refactor nodes

### DIFF
--- a/lib/smartdown/engine.rb
+++ b/lib/smartdown/engine.rb
@@ -30,15 +30,11 @@ module Smartdown
       while !unprocessed_responses.empty? do
         current_node = flow.node(state.get(:current_node))
 
-        if current_node.elements.any?{|element| element.class.to_s.include?("Smartdown::Model::Element::StartButton") }
+        if current_node.is_start_page_node?
           # If it's a start page node, we've got to do something different because of the preceeding 'y' answer
           transition = Transition.new(state, current_node, unprocessed_responses.shift(1))
         else
-          questions = current_node.elements.select{|element|
-            element.class.to_s.include?("Smartdown::Model::Element::Question")
-          }
-
-          answers = questions.map do |question|
+          answers = current_node.questions.map do |question|
             question.answer_type.new(question, unprocessed_responses.shift)
           end
 

--- a/lib/smartdown/engine.rb
+++ b/lib/smartdown/engine.rb
@@ -24,22 +24,26 @@ module Smartdown
       {}.merge(@initial_state)
     end
 
-    def process(responses, test_start_state = nil)
+    def process(raw_responses, test_start_state = nil)
       state = test_start_state || build_start_state
-      unprocessed_responses = responses
+      unprocessed_responses = raw_responses
       while !unprocessed_responses.empty? do
-        nb_questions = 0
         current_node = flow.node(state.get(:current_node))
-        nb_questions += current_node.elements.select{|element|
-          element.class.to_s.include?("Smartdown::Model::Element::Question")
-        }.count
-        #There is at least one relevant input per transition for now:
-        #Transition from start to first question relies on an input, regardless of its value
-        nb_relevant_inputs = [nb_questions, 1].max
-        input_array = unprocessed_responses.take(nb_relevant_inputs)
-        unprocessed_responses = unprocessed_responses.drop(nb_relevant_inputs)
 
-        transition = Transition.new(state, current_node, input_array)
+        if current_node.elements.any?{|element| element.class.to_s.include?("Smartdown::Model::Element::StartButton") }
+          # If it's a start page node, we've got to do something different because of the preceeding 'y' answer
+          transition = Transition.new(state, current_node, unprocessed_responses.shift(1))
+        else
+          questions = current_node.elements.select{|element|
+            element.class.to_s.include?("Smartdown::Model::Element::Question")
+          }
+
+          answers = questions.map do |question|
+            question.answer_type.new(question, unprocessed_responses.shift)
+          end
+
+          transition = Transition.new(state, current_node, answers)
+        end
         state = transition.next_state
       end
       state

--- a/lib/smartdown/engine/transition.rb
+++ b/lib/smartdown/engine/transition.rb
@@ -26,24 +26,15 @@ module Smartdown
 
     private
       def next_node_from_next_node_rules
-        next_node_rules && first_matching_rule(next_node_rules.rules).outcome
+        node.next_node_rules && first_matching_rule(node.next_node_rules.rules).outcome
       end
 
       def next_node_from_start_button
-        start_button && start_button.start_node
+        node.start_button && node.start_button.start_node
       end
 
       def input_variable_names_from_question
-        questions = node.elements.select { |e| e.class.to_s.include?("Smartdown::Model::Element::Question") }
-        questions.map(&:name)
-      end
-
-      def next_node_rules
-        node.elements.find { |e| e.is_a?(Smartdown::Model::NextNodeRules) }
-      end
-
-      def start_button
-        node.elements.find { |e| e.is_a?(Smartdown::Model::Element::StartButton) }
+        node.questions.map(&:name)
       end
 
       def first_matching_rule(rules)

--- a/lib/smartdown/model/answer/base.rb
+++ b/lib/smartdown/model/answer/base.rb
@@ -4,7 +4,31 @@ module Smartdown
       class Base
         extend Forwardable
 
-        def_delegators :value, :to_s, :==, :<, :>, :<=, :>=
+        def_delegators :value, :to_s
+
+        def value_type
+          ::String
+        end
+
+        def ==(other)
+          value == parse_comparison_object(other)
+        end
+
+        def <(other)
+          value < parse_comparison_object(other)
+        end
+
+        def >(other)
+          value > parse_comparison_object(other)
+        end
+
+        def <=(other)
+          value <= parse_comparison_object(other)
+        end
+
+        def >=(other)
+          value >= parse_comparison_object(other)
+        end
 
         attr_reader :question, :value
 
@@ -14,6 +38,16 @@ module Smartdown
         end
 
       private
+        def parse_comparison_object(comparison_object)
+          if comparison_object.is_a? Base
+            comparison_object.value
+          elsif comparison_object.is_a? value_type
+            comparison_object
+          else
+            parse_value(comparison_object)
+          end
+        end
+
         def parse_value(value)
           value
         end

--- a/lib/smartdown/model/answer/base.rb
+++ b/lib/smartdown/model/answer/base.rb
@@ -4,7 +4,7 @@ module Smartdown
       class Base
         extend Forwardable
 
-        def_delegators :value, :to_s
+        def_delegators :value, :to_s, :to_i, :to_f, :+, :-, :*, :/
 
         def value_type
           ::String

--- a/lib/smartdown/model/answer/base.rb
+++ b/lib/smartdown/model/answer/base.rb
@@ -3,6 +3,7 @@ module Smartdown
     module Answer
       class Base
         extend Forwardable
+        include Comparable
 
         def_delegators :value, :to_s, :to_i, :to_f, :+, :-, :*, :/
 
@@ -10,24 +11,8 @@ module Smartdown
           ::String
         end
 
-        def ==(other)
-          value == parse_comparison_object(other)
-        end
-
-        def <(other)
-          value < parse_comparison_object(other)
-        end
-
-        def >(other)
-          value > parse_comparison_object(other)
-        end
-
-        def <=(other)
-          value <= parse_comparison_object(other)
-        end
-
-        def >=(other)
-          value >= parse_comparison_object(other)
+        def <=>(other)
+          value <=> parse_comparison_object(other)
         end
 
         attr_reader :question, :value

--- a/lib/smartdown/model/answer/base.rb
+++ b/lib/smartdown/model/answer/base.rb
@@ -1,0 +1,23 @@
+module Smartdown
+  module Model
+    module Answer
+      class Base
+        extend Forwardable
+
+        def_delegators :value, :to_s, :==, :<, :>, :<=, :>=
+
+        attr_reader :question, :value
+
+        def initialize(question, value)
+          @question = question
+          @value = parse_value(value)
+        end
+
+      private
+        def parse_value(value)
+          value
+        end
+      end
+    end
+  end
+end

--- a/lib/smartdown/model/answer/date.rb
+++ b/lib/smartdown/model/answer/date.rb
@@ -1,0 +1,18 @@
+require_relative "base"
+
+module Smartdown
+  module Model
+    module Answer
+      class Date < Base
+        def to_s
+          value.strftime("%Y-%-m-%-d")
+        end
+
+      private
+        def parse_value(value)
+          ::Date.parse(value)
+        end
+      end
+    end
+  end
+end

--- a/lib/smartdown/model/answer/date.rb
+++ b/lib/smartdown/model/answer/date.rb
@@ -4,6 +4,10 @@ module Smartdown
   module Model
     module Answer
       class Date < Base
+        def value_type
+          ::Date
+        end
+
         def to_s
           value.strftime("%Y-%-m-%-d")
         end

--- a/lib/smartdown/model/answer/multiple_choice.rb
+++ b/lib/smartdown/model/answer/multiple_choice.rb
@@ -1,0 +1,11 @@
+require_relative "base"
+
+module Smartdown
+  module Model
+    module Answer
+      class MultipleChoice < Base
+
+      end
+    end
+  end
+end

--- a/lib/smartdown/model/answer/multiple_choice.rb
+++ b/lib/smartdown/model/answer/multiple_choice.rb
@@ -4,7 +4,9 @@ module Smartdown
   module Model
     module Answer
       class MultipleChoice < Base
-
+        def value_type
+          ::String
+        end
       end
     end
   end

--- a/lib/smartdown/model/answer/salary.rb
+++ b/lib/smartdown/model/answer/salary.rb
@@ -6,6 +6,10 @@ module Smartdown
       class Salary < Base
         attr_reader :period, :amount_per_period
 
+        def value_type
+          ::Float
+        end
+
         def to_s
           "#{'%.2f' % amount_per_period} per #{period}"
         end

--- a/lib/smartdown/model/answer/salary.rb
+++ b/lib/smartdown/model/answer/salary.rb
@@ -1,0 +1,33 @@
+require_relative "base"
+
+module Smartdown
+  module Model
+    module Answer
+      class Salary < Base
+        attr_reader :period, :amount_per_period
+
+        def to_s
+          "#{'%.2f' % amount_per_period} per #{period}"
+        end
+
+      private
+        def parse_value(value)
+          @amount_per_period, @period = value.split(/-|\W*per\W*/)
+          @amount_per_period = @amount_per_period.to_f
+          yearly_total
+        end
+
+        def yearly_total
+          case period
+          when "week"
+            amount_per_period * 52
+          when "month"
+            amount_per_period * 12
+          when "year"
+            amount_per_period
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/smartdown/model/element/question/date.rb
+++ b/lib/smartdown/model/element/question/date.rb
@@ -1,8 +1,14 @@
+require 'smartdown/model/answer/date'
+
 module Smartdown
   module Model
     module Element
       module Question
-        Date = Struct.new(:name)
+        class Date < Struct.new(:name)
+          def answer_type
+            Smartdown::Model::Answer::Date
+          end
+        end
       end
     end
   end

--- a/lib/smartdown/model/element/question/multiple_choice.rb
+++ b/lib/smartdown/model/element/question/multiple_choice.rb
@@ -1,8 +1,14 @@
+require 'smartdown/model/answer/multiple_choice'
+
 module Smartdown
   module Model
     module Element
       module Question
-        MultipleChoice = Struct.new(:name, :choices)
+        class MultipleChoice < Struct.new(:name, :choices)
+          def answer_type
+            Smartdown::Model::Answer::MultipleChoice
+          end
+        end
       end
     end
   end

--- a/lib/smartdown/model/element/question/salary.rb
+++ b/lib/smartdown/model/element/question/salary.rb
@@ -1,8 +1,14 @@
+require 'smartdown/model/answer/salary'
+
 module Smartdown
   module Model
     module Element
       module Question
-        Salary = Struct.new(:name)
+        class Salary < Struct.new(:name)
+          def answer_type
+            Smartdown::Model::Answer::Salary
+          end
+        end
       end
     end
   end

--- a/lib/smartdown/model/node.rb
+++ b/lib/smartdown/model/node.rb
@@ -7,18 +7,30 @@ module Smartdown
         super(name, elements, front_matter || Smartdown::Model::FrontMatter.new)
       end
 
-      def questions
-        elements.select do |element|
-          element.class.to_s.include?("Smartdown::Model::Element::Question")
-        end
-      end
-
       def title
         h1s.first ? h1s.first.content : ""
       end
 
       def body
         markdown_blocks[1..-1].map { |block| as_markdown(block) }.compact.join("\n")
+      end
+
+      def questions
+        @questions ||= elements.select do |element|
+          element.class.to_s.include?("Smartdown::Model::Element::Question")
+        end
+      end
+
+      def next_node_rules
+        @next_node_rules ||= elements.find { |e| e.is_a?(Smartdown::Model::NextNodeRules) }
+      end
+
+      def start_button
+        @start_button ||= elements.find { |e| e.is_a?(Smartdown::Model::Element::StartButton) }
+      end
+
+      def is_start_page_node?
+        @is_start_page_node ||= !!start_button
       end
 
       private

--- a/lib/smartdown/model/predicate/comparison/greater.rb
+++ b/lib/smartdown/model/predicate/comparison/greater.rb
@@ -8,11 +8,7 @@ module Smartdown
         class Greater < Base
           def evaluate(state)
             variable = state.get(varname)
-            if /(\d{4})-(\d{1,2})-(\d{1,2})/.match(value)
-              Date.parse(variable) > Date.parse(value)
-            else
-              variable > value
-            end
+            variable > value
           end
 
           def humanize

--- a/lib/smartdown/model/predicate/comparison/greater_or_equal.rb
+++ b/lib/smartdown/model/predicate/comparison/greater_or_equal.rb
@@ -8,11 +8,7 @@ module Smartdown
         class GreaterOrEqual < Base
           def evaluate(state)
             variable = state.get(varname)
-            if /(\d{4})-(\d{1,2})-(\d{1,2})/.match(value)
-              Date.parse(variable) >= Date.parse(value)
-            else
-              variable >= value
-            end
+            variable >= value
           end
 
           def humanize

--- a/lib/smartdown/model/predicate/comparison/less.rb
+++ b/lib/smartdown/model/predicate/comparison/less.rb
@@ -8,11 +8,7 @@ module Smartdown
         class Less < Base
           def evaluate(state)
             variable = state.get(varname)
-            if /(\d{4})-(\d{1,2})-(\d{1,2})/.match(value)
-              Date.parse(variable) < Date.parse(value)
-            else
-              variable < value
-            end
+            variable < value
           end
 
           def humanize

--- a/lib/smartdown/model/predicate/comparison/less_or_equal.rb
+++ b/lib/smartdown/model/predicate/comparison/less_or_equal.rb
@@ -8,11 +8,7 @@ module Smartdown
         class LessOrEqual < Base
           def evaluate(state)
             variable = state.get(varname)
-            if /(\d{4})-(\d{1,2})-(\d{1,2})/.match(value)
-              Date.parse(variable) <= Date.parse(value)
-            else
-              variable <= value
-            end
+            variable <= value
           end
 
           def humanize

--- a/lib/smartdown/model/predicate/set_membership.rb
+++ b/lib/smartdown/model/predicate/set_membership.rb
@@ -3,7 +3,7 @@ module Smartdown
     module Predicate
       SetMembership = Struct.new(:varname, :values) do
         def evaluate(state)
-          values.include?(state.get(varname))
+          values.any? {|value| state.get(varname) == value }
         end
 
         def humanize

--- a/spec/model/answer/base_spec.rb
+++ b/spec/model/answer/base_spec.rb
@@ -14,4 +14,10 @@ describe Smartdown::Model::Answer::Base do
       expect(instance.value).to eql "parsed value"
     end
   end
+
+  describe "simple type behaviour" do
+    [:==, :<, :>, :<=, :>=, :to_s, :to_i, :to_f, :+, :-, :*, :/].each do |method|
+      it { should respond_to(method) }
+    end
+  end
 end

--- a/spec/model/answer/base_spec.rb
+++ b/spec/model/answer/base_spec.rb
@@ -14,30 +14,4 @@ describe Smartdown::Model::Answer::Base do
       expect(instance.value).to eql "parsed value"
     end
   end
-
-  specify { expect(instance.to_s).to eql "a value" }
-
-  describe "comparisons" do
-    specify { expect(instance == "a value").to eql true }
-
-    context "with an integer value" do
-      let(:value) { 10 }
-
-      specify { expect(instance < 11).to eql true }
-      specify { expect(instance < 10).to eql false }
-      specify { expect(instance < 9).to eql false }
-
-      specify { expect(instance > 11).to eql false }
-      specify { expect(instance > 10).to eql false }
-      specify { expect(instance > 9).to eql true }
-
-      specify { expect(instance <= 11).to eql true }
-      specify { expect(instance <= 10).to eql true }
-      specify { expect(instance <= 9).to eql false }
-
-      specify { expect(instance >= 11).to eql false }
-      specify { expect(instance >= 10).to eql true }
-      specify { expect(instance >= 9).to eql true }
-    end
-  end
 end

--- a/spec/model/answer/base_spec.rb
+++ b/spec/model/answer/base_spec.rb
@@ -1,0 +1,43 @@
+require 'smartdown/model/answer/base'
+
+describe Smartdown::Model::Answer::Base do
+  let(:question) { :a_question }
+  let(:value) { 'a value' }
+
+  subject(:instance) {Smartdown::Model::Answer::Base.new(question, value)}
+
+  specify { expect(instance.question).to eql question }
+
+  describe "value parsing" do
+    it "should assign the return value of parse_value (to be implemented by sub-classes) to value" do
+      expect_any_instance_of(Smartdown::Model::Answer::Base).to receive(:parse_value).with(value).and_return("parsed value")
+      expect(instance.value).to eql "parsed value"
+    end
+  end
+
+  specify { expect(instance.to_s).to eql "a value" }
+
+  describe "comparisons" do
+    specify { expect(instance == "a value").to eql true }
+
+    context "with an integer value" do
+      let(:value) { 10 }
+
+      specify { expect(instance < 11).to eql true }
+      specify { expect(instance < 10).to eql false }
+      specify { expect(instance < 9).to eql false }
+
+      specify { expect(instance > 11).to eql false }
+      specify { expect(instance > 10).to eql false }
+      specify { expect(instance > 9).to eql true }
+
+      specify { expect(instance <= 11).to eql true }
+      specify { expect(instance <= 10).to eql true }
+      specify { expect(instance <= 9).to eql false }
+
+      specify { expect(instance >= 11).to eql false }
+      specify { expect(instance >= 10).to eql true }
+      specify { expect(instance >= 9).to eql true }
+    end
+  end
+end

--- a/spec/model/answer/date_spec.rb
+++ b/spec/model/answer/date_spec.rb
@@ -8,4 +8,70 @@ describe Smartdown::Model::Answer::Date do
 
   specify { expect(instance.value).to eql Date.new(2014, 9, 4) }
   specify { expect(instance.to_s).to eql "2014-9-4" }
+
+
+  describe "comparisons" do
+    let(:date_string) { "2000-1-10" }
+
+    context "comparing against ::Dates" do
+
+      specify { expect(instance == Date.new(2000, 1, 10)).to eql true }
+
+      specify { expect(instance < Date.new(2000, 1, 11)).to eql true }
+      specify { expect(instance < Date.new(2000, 1, 10)).to eql false }
+      specify { expect(instance < Date.new(2000, 1, 9)).to eql false }
+
+      specify { expect(instance > Date.new(2000, 1, 11)).to eql false }
+      specify { expect(instance > Date.new(2000, 1, 10)).to eql false }
+      specify { expect(instance > Date.new(2000, 1, 9)).to eql true }
+
+      specify { expect(instance <= Date.new(2000, 1, 11)).to eql true }
+      specify { expect(instance <= Date.new(2000, 1, 10)).to eql true }
+      specify { expect(instance <= Date.new(2000, 1, 9)).to eql false }
+
+      specify { expect(instance >= Date.new(2000, 1, 11)).to eql false }
+      specify { expect(instance >= Date.new(2000, 1, 10)).to eql true }
+      specify { expect(instance >= Date.new(2000, 1, 9)).to eql true }
+    end
+
+    context "comparing against strings" do
+      specify { expect(instance == "2000-1-10").to eql true }
+
+      specify { expect(instance < "2000-1-11").to eql true }
+      specify { expect(instance < "2000-1-10").to eql false }
+      specify { expect(instance < "2000-1-9").to eql false }
+
+      specify { expect(instance > "2000-1-11").to eql false }
+      specify { expect(instance > "2000-1-10").to eql false }
+      specify { expect(instance > "2000-1-9").to eql true }
+
+      specify { expect(instance <= "2000-1-11").to eql true }
+      specify { expect(instance <= "2000-1-10").to eql true }
+      specify { expect(instance <= "2000-1-9").to eql false }
+
+      specify { expect(instance >= "2000-1-11").to eql false }
+      specify { expect(instance >= "2000-1-10").to eql true }
+      specify { expect(instance >= "2000-1-9").to eql true }
+    end
+
+    context "comparing against Answer::Dates" do
+      specify { expect(instance == described_class.new(nil, "2000-1-10")).to eql true }
+
+      specify { expect(instance < described_class.new(nil, "2000-1-11")).to eql true }
+      specify { expect(instance < described_class.new(nil, "2000-1-10")).to eql false }
+      specify { expect(instance < described_class.new(nil, "2000-1-9")).to eql false }
+
+      specify { expect(instance > described_class.new(nil, "2000-1-11")).to eql false }
+      specify { expect(instance > described_class.new(nil, "2000-1-10")).to eql false }
+      specify { expect(instance > described_class.new(nil, "2000-1-9")).to eql true }
+
+      specify { expect(instance <= described_class.new(nil, "2000-1-11")).to eql true }
+      specify { expect(instance <= described_class.new(nil, "2000-1-10")).to eql true }
+      specify { expect(instance <= described_class.new(nil, "2000-1-9")).to eql false }
+
+      specify { expect(instance >= described_class.new(nil, "2000-1-11")).to eql false }
+      specify { expect(instance >= described_class.new(nil, "2000-1-10")).to eql true }
+      specify { expect(instance >= described_class.new(nil, "2000-1-9")).to eql true }
+    end
+  end
 end

--- a/spec/model/answer/date_spec.rb
+++ b/spec/model/answer/date_spec.rb
@@ -1,0 +1,11 @@
+require 'smartdown/model/answer/date'
+require 'smartdown/model/element/question/date'
+
+describe Smartdown::Model::Answer::Date do
+  let(:date_string) { "2014-9-4" }
+  let(:question) { Smartdown::Model::Element::Question::Date.new("a_date") }
+  subject(:instance) { described_class.new(question, date_string) }
+
+  specify { expect(instance.value).to eql Date.new(2014, 9, 4) }
+  specify { expect(instance.to_s).to eql "2014-9-4" }
+end

--- a/spec/model/answer/salary_spec.rb
+++ b/spec/model/answer/salary_spec.rb
@@ -27,4 +27,72 @@ describe Smartdown::Model::Answer::Salary do
     let(:salary_string) { "20000-year" }
     specify { expect(instance.value).to eql 20000.0 }
   end
+
+
+  describe "comparisons" do
+    let(:salary_string) { "1200-week" } # equivalent to 62,400 yearly or 5200 monthly
+
+    context "comparing against ::Floats" do
+      specify { expect(instance == 62400.0).to eql true }
+
+      specify { expect(instance < 62400.1).to eql true }
+      specify { expect(instance < 62400.0).to eql false }
+      specify { expect(instance < 62399.9).to eql false }
+
+      specify { expect(instance > 62400.1).to eql false }
+      specify { expect(instance > 62400.0).to eql false }
+      specify { expect(instance > 62399.9).to eql true }
+
+      specify { expect(instance <= 62400.1).to eql true }
+      specify { expect(instance <= 62400.0).to eql true }
+      specify { expect(instance <= 62399.9).to eql false }
+
+      specify { expect(instance >= 62400.1).to eql false }
+      specify { expect(instance >= 62400.0).to eql true }
+      specify { expect(instance >= 62399.9).to eql true }
+    end
+
+    context "comparing against strings" do
+      specify { expect(instance == "1200-week").to eql true }
+      specify { expect(instance == "5200-month").to eql true }
+      specify { expect(instance == "62400-year").to eql true }
+      specify { expect(instance == "10-month").to eql false }
+
+      specify { expect(instance < "62400.1-year").to eql true }
+      specify { expect(instance < "5200.0-month").to eql false }
+      specify { expect(instance < "1199.9-week").to eql false }
+
+      specify { expect(instance > "1200.1-week").to eql false }
+      specify { expect(instance > "62400-year").to eql false }
+      specify { expect(instance > "5199.9-month").to eql true }
+
+      specify { expect(instance <= "62400.1-year").to eql true }
+      specify { expect(instance <= "5200.0-month").to eql true }
+      specify { expect(instance <= "1199.9-week").to eql false }
+
+      specify { expect(instance >= "1200.1-week").to eql false }
+      specify { expect(instance >= "62400-year").to eql true }
+      specify { expect(instance >= "5199.9-month").to eql true }
+    end
+
+    context "comparing against Answer::Salaries" do
+      specify { expect(instance == described_class.new(nil, "1200-week")).to eql true }
+
+      specify { expect(instance < described_class.new(nil, "1200.1-week")).to eql true }
+      specify { expect(instance < described_class.new(nil, "1200.0-week")).to eql false }
+      specify { expect(instance < described_class.new(nil, "1199.9-week")).to eql false }
+
+      specify { expect(instance > described_class.new(nil, "1200.1-week")).to eql false }
+      specify { expect(instance > described_class.new(nil, "1200.0-week")).to eql false }
+      specify { expect(instance > described_class.new(nil, "1199.9-week")).to eql true }
+
+      specify { expect(instance <= described_class.new(nil, "1200.1-week")).to eql true }
+      specify { expect(instance <= described_class.new(nil, "1200.0-week")).to eql true }
+      specify { expect(instance <= described_class.new(nil, "1199.9-week")).to eql false }
+
+      specify { expect(instance >= described_class.new(nil, "1200.1-week")).to eql false }
+      specify { expect(instance >= described_class.new(nil, "1200.0-week")).to eql true }
+      specify { expect(instance >= described_class.new(nil, "1199.9-week")).to eql true }
+    end
+  end
 end

--- a/spec/model/answer/salary_spec.rb
+++ b/spec/model/answer/salary_spec.rb
@@ -1,0 +1,30 @@
+require 'smartdown/model/answer/date'
+require 'smartdown/model/element/question/date'
+
+describe Smartdown::Model::Answer::Salary do
+  let(:salary_string) { "500-week" }
+  let(:question) { Smartdown::Model::Element::Question::Date.new("a_date") }
+  subject(:instance) { described_class.new(question, salary_string) }
+
+  specify { expect(instance.period).to eql('week') }
+  specify { expect(instance.amount_per_period).to eql(500.00) }
+
+  it "as a string, it should declare itself in the initial format provided" do
+    expect(instance.to_s).to eql("500.00 per week")
+  end
+
+  context "declared by week" do
+    let(:salary_string) { "500-week" }
+    specify { expect(instance.value).to eql 500.0 * 52 }
+  end
+
+  context "declared by month" do
+    let(:salary_string) { "2000-month" }
+    specify { expect(instance.value).to eql 2000.0 * 12 }
+  end
+
+  context "declared by year" do
+    let(:salary_string) { "20000-year" }
+    specify { expect(instance.value).to eql 20000.0 }
+  end
+end

--- a/spec/model/node_spec.rb
+++ b/spec/model/node_spec.rb
@@ -3,9 +3,9 @@ require 'smartdown/model/node'
 describe Smartdown::Model::Node do
   let(:name) { "my node" }
   let(:elements) { [] }
+  subject(:node) { described_class.new(name, elements) }
 
   describe "#new" do
-    subject(:node) { described_class.new(name, elements) }
 
     it "accepts name and list of body blocks" do
       expect(node.name).to eq(name)
@@ -27,6 +27,50 @@ describe Smartdown::Model::Node do
       it "uses it" do
         expect(node.front_matter).to eq(front_matter)
       end
+    end
+  end
+
+  describe "#questions" do
+    context "with seval elements, some of which are questions" do
+      let(:elements) { [
+        Smartdown::Model::Element::MarkdownHeading.new("A Heading"),
+        Smartdown::Model::Element::Question::Date.new("a_date_question"),
+        Smartdown::Model::Element::Question::MultipleChoice.new("a_multiple_choice_question"),
+        Smartdown::Model::Element::MarkdownParagraph.new("Some text"),
+      ] }
+      specify { expect(node.questions).to eq elements[1..2] }
+    end
+  end
+
+  describe "#next_node_rules" do
+    context "with elements, one of which is a NextNodeRules questions" do
+      let(:elements) { [
+        Smartdown::Model::Element::MarkdownHeading.new("A Heading"),
+        Smartdown::Model::NextNodeRules.new(:rules)
+      ] }
+      specify { expect(node.next_node_rules).to eq elements[1] }
+    end
+  end
+
+  describe "#start_button" do
+    context "with elements, one of which is a StartButton questions" do
+      let(:elements) { [
+        Smartdown::Model::Element::StartButton.new(:a_start_node),
+        Smartdown::Model::NextNodeRules.new(:rules)
+      ] }
+      specify { expect(node.start_button).to eq elements[0] }
+    end
+  end
+
+  describe "#is_start_page_node?" do
+    context "with a StartButton element" do
+      let (:elements) { [Smartdown::Model::Element::StartButton.new(:some_start_node)] }
+      specify { expect(node.is_start_page_node?).to eql true }
+    end
+
+    context "without a StartButton element" do
+      let (:elements) { [] }
+      specify { expect(node.is_start_page_node?).to eql false }
     end
   end
 end


### PR DESCRIPTION
This moves some finders for elements (eg. `node.elements.find { |e| e.is_a?(Smartdown::Model::NextNodeRules) }`) down into the Node model as a step towards having this done at the parsing level.

Includes https://github.com/alphagov/smartdown/pull/50, please merge after
