### PR TITLE
Fix named predicate/otherwise parsing errors

### DIFF
--- a/lib/smartdown/engine.rb
+++ b/lib/smartdown/engine.rb
@@ -21,9 +21,7 @@ module Smartdown
     end
 
     def default_predicates
-      {
-        otherwise: Smartdown::Model::Predicate::Otherwise.new
-      }.merge(@initial_state)
+      {}.merge(@initial_state)
     end
 
     def process(responses, test_start_state = nil)

--- a/lib/smartdown/model/predicate/otherwise.rb
+++ b/lib/smartdown/model/predicate/otherwise.rb
@@ -5,6 +5,10 @@ module Smartdown
         def evaluate(state)
             true
         end
+
+        def ==(o)
+          o.class == self.class
+        end
       end
     end
   end

--- a/lib/smartdown/parser/node_transform.rb
+++ b/lib/smartdown/parser/node_transform.rb
@@ -121,6 +121,10 @@ module Smartdown
         Smartdown::Model::Predicate::Named.new(name)
       }
 
+      rule(:otherwise_predicate => simple(:name) ) {
+        Smartdown::Model::Predicate::Otherwise.new
+      }
+
       rule(:combined_predicate => {first_predicate: subtree(:first_predicate), and_predicates: subtree(:and_predicates) }) {
         Smartdown::Model::Predicate::Combined.new([first_predicate]+and_predicates)
       }

--- a/lib/smartdown/parser/node_transform.rb
+++ b/lib/smartdown/parser/node_transform.rb
@@ -121,7 +121,6 @@ module Smartdown
         Smartdown::Model::Predicate::Named.new(name)
       }
 
-
       rule(:combined_predicate => {first_predicate: subtree(:first_predicate), and_predicates: subtree(:and_predicates) }) {
         Smartdown::Model::Predicate::Combined.new([first_predicate]+and_predicates)
       }

--- a/lib/smartdown/parser/predicates.rb
+++ b/lib/smartdown/parser/predicates.rb
@@ -37,10 +37,15 @@ module Smartdown
         (identifier >> str('?')).as(:named_predicate)
       }
 
+      rule(:otherwise_predicate) {
+        str('otherwise').as(:named_predicate)
+      }
+
       rule(:predicate) {
         equality_predicate.as(:equality_predicate) |
         set_membership_predicate.as(:set_membership_predicate) |
         comparison_predicate.as(:comparison_predicate) |
+        otherwise_predicate |
         named_predicate
       }
 

--- a/lib/smartdown/parser/predicates.rb
+++ b/lib/smartdown/parser/predicates.rb
@@ -38,7 +38,7 @@ module Smartdown
       }
 
       rule(:otherwise_predicate) {
-        str('otherwise').as(:named_predicate)
+        str('otherwise').as(:otherwise_predicate)
       }
 
       rule(:predicate) {

--- a/spec/acceptance/parsing_spec.rb
+++ b/spec/acceptance/parsing_spec.rb
@@ -104,6 +104,14 @@ EXPECTED
       expect(flow.nodes.map(&:name)).to eq(["question-and-outcome", "q1", "o1"])
     end
   end
+
+  context "full flow example" do
+    subject(:flow) { Smartdown.parse(fixture("animal-example-simple")) }
+
+    it "parses" do
+      expect(flow.instance_of? Smartdown::Model::Flow).to eq(true)
+    end
+  end
 end
 
 

--- a/spec/fixtures/acceptance/animal-example-simple/animal-example-simple.txt
+++ b/spec/fixtures/acceptance/animal-example-simple/animal-example-simple.txt
@@ -1,0 +1,25 @@
+meta_description: Animals eh?
+satisfies_need: 100982
+status: draft
+
+# A simple example of smartdown
+
+Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod
+tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
+quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+consequat.
+
+Duis aute irure dolor in reprehenderit in voluptate velit esse
+cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non
+proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+
+## Before you start, you will need
+
+* To know the kind of feline you have
+* Any animal training certification documents
+
+[start: question_1]
+
+## Devolved body
+
+Which is really just body content after the start button

--- a/spec/fixtures/acceptance/animal-example-simple/outcomes/outcome_safe_pet.txt
+++ b/spec/fixtures/acceptance/animal-example-simple/outcomes/outcome_safe_pet.txt
@@ -1,0 +1,69 @@
+# You picked a safe pet
+
+Good call.
+
+# Markdown/Govspeak examples
+
+## H2 example
+
+With answers, that are smart. Down with that?
+
+Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod
+tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
+quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+
+### H3 example
+
+consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse
+cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non
+proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+
+## List
+
+* one
+* two
+* three
+
+## List 2
+
+- A
+- B
+- C
+
+## List 3
+
++ Up
++ Down
++ Left
++ Right
+
+^This is an information callout.^
+
+%This is a warning callout - use it when there’s a risk of getting a fine or going to prison.%
+
+$E
+**Example**
+Your income for the last tax year was £30,000. You think your income will drop to £20,000 this tax year. Enter £22,500 into the calculator.
+$E
+
+{::highlight-answer}
+The VAT rate is *20%*
+{:/highlight-answer}
+
+
+$C
+**Student Finance England**
+Telephone: 0845 300 5090
+Minicom: 0845 604 4434
+[Find out about call charges](http://www.gov.uk/call-charges)
+$C
+
+$A
+Hercules House
+Hercules Road
+London SE1 7DU
+$A
+
+$D
+[Download the 'Example application form' (PDF, 35KB)](http://example.com/ "Example form")
+$D

--- a/spec/fixtures/acceptance/animal-example-simple/outcomes/outcome_tigers_are_fine.txt
+++ b/spec/fixtures/acceptance/animal-example-simple/outcomes/outcome_tigers_are_fine.txt
@@ -1,0 +1,9 @@
+# Tigers are fine
+
+You haven't trained with tigers, but you'll be alright, probably.
+
+[next_steps]
+###You bought a tiger? Seriously?
+
+[Your nearest hospital](https://gov.uk/hospital)
+[end_next_steps]

--- a/spec/fixtures/acceptance/animal-example-simple/outcomes/outcome_trained_with_lions.txt
+++ b/spec/fixtures/acceptance/animal-example-simple/outcomes/outcome_trained_with_lions.txt
@@ -1,0 +1,3 @@
+# You've trained with lions
+
+You'll be alright, I think.

--- a/spec/fixtures/acceptance/animal-example-simple/outcomes/outcome_untrained_with_lions.txt
+++ b/spec/fixtures/acceptance/animal-example-simple/outcomes/outcome_untrained_with_lions.txt
@@ -1,0 +1,3 @@
+# You're not trained with lions
+
+Nice to know you.

--- a/spec/fixtures/acceptance/animal-example-simple/questions/question_1.txt
+++ b/spec/fixtures/acceptance/animal-example-simple/questions/question_1.txt
@@ -1,0 +1,13 @@
+# Amazing page title
+
+# What type of feline do you have?
+
+Check the serial number by the tail.
+
+[choice: question_1]
+* lion: Lion
+* tiger: Tiger
+* cat: Cat
+
+* question_1 in {lion tiger} => question_2
+* otherwise => outcome_safe_pet

--- a/spec/fixtures/acceptance/animal-example-simple/questions/question_2.txt
+++ b/spec/fixtures/acceptance/animal-example-simple/questions/question_2.txt
@@ -1,0 +1,10 @@
+# Are you trained for lions?
+
+[choice: trained_for_lions]
+* yes: Yes
+* no: No
+
+* question_1 is 'lion'
+  * trained_for_lions is 'yes' => outcome_trained_with_lions
+  * otherwise => outcome_untrained_with_lions
+* otherwise => outcome_tigers_are_fine

--- a/spec/parser/predicates_spec.rb
+++ b/spec/parser/predicates_spec.rb
@@ -65,7 +65,7 @@ describe Smartdown::Parser::Predicates do
   describe "otherwise predicate" do
     subject(:parser) { described_class.new }
 
-    it { should parse("otherwise").as(named_predicate: "otherwise") }
+    it { should parse("otherwise").as(otherwise_predicate: "otherwise") }
     it { should_not parse("other") }
 
     describe "transformed" do
@@ -75,7 +75,7 @@ describe Smartdown::Parser::Predicates do
         Smartdown::Parser::NodeInterpreter.new(node_name, source, parser: parser).interpret
       }
 
-      it { should eq(Smartdown::Model::Predicate::Named.new("otherwise")) }
+      it { should eq(Smartdown::Model::Predicate::Otherwise.new) }
     end
   end
 

--- a/spec/parser/predicates_spec.rb
+++ b/spec/parser/predicates_spec.rb
@@ -62,6 +62,23 @@ describe Smartdown::Parser::Predicates do
     end
   end
 
+  describe "otherwise predicate" do
+    subject(:parser) { described_class.new }
+
+    it { should parse("otherwise").as(named_predicate: "otherwise") }
+    it { should_not parse("other") }
+
+    describe "transformed" do
+      let(:node_name) { "my_node" }
+      let(:source) { "otherwise" }
+      subject(:transformed) {
+        Smartdown::Parser::NodeInterpreter.new(node_name, source, parser: parser).interpret
+      }
+
+      it { should eq(Smartdown::Model::Predicate::Named.new("otherwise")) }
+    end
+  end
+
   describe "predicate AND predicate" do
     subject(:parser) { described_class.new }
 


### PR DESCRIPTION
As a result of https://github.com/alphagov/smartdown/commit/61b1bb2b848dbddc2dda859dda27e3030b1bbe7f  the parsing of `otherwise` as a `NamedPredicate` failed. The behaviour of otherwise relied on a the weird side effect of it being treated as a predicate, instead make otherwise an explicit language construct/operator.

Adds a high level acceptance test/fixture to catch regression and similar high-level parsing errors that weren't covered by tests.
