### PR TITLE
Snippets

### DIFF
--- a/lib/smartdown/parser/directory_input.rb
+++ b/lib/smartdown/parser/directory_input.rb
@@ -23,6 +23,10 @@ module Smartdown
         read_dir("scenarios")
       end
 
+      def snippets
+        read_dir("snippets")
+      end
+
       def filenames_hash
         {
           coversheet: coversheet.to_s,

--- a/lib/smartdown/parser/flow_interpreter.rb
+++ b/lib/smartdown/parser/flow_interpreter.rb
@@ -1,5 +1,6 @@
 require 'smartdown/model/flow'
 require 'smartdown/parser/node_interpreter'
+require 'smartdown/parser/snippet_pre_parser'
 
 module Smartdown
   module Parser
@@ -20,7 +21,7 @@ module Smartdown
       attr_reader :flow_input
 
       def initialize(flow_input)
-        @flow_input = flow_input
+        @flow_input = pre_parse(flow_input)
       end
 
       def interpret
@@ -44,6 +45,10 @@ module Smartdown
         Smartdown::Parser::NodeInterpreter.new(input_data.name, input_data.read).interpret
       rescue Parslet::ParseFailed => error
         raise ParseError.new(input_data.to_s, error)
+      end
+
+      def pre_parse(flow_input)
+        SnippetPreParser.parse(flow_input)
       end
     end
   end

--- a/lib/smartdown/parser/flow_interpreter.rb
+++ b/lib/smartdown/parser/flow_interpreter.rb
@@ -33,11 +33,11 @@ module Smartdown
       end
 
       def questions
-        flow_input.questions.map { |i| interpret_node(i) }
+        flow_input.questions.map { |question_data| interpret_node(question_data) }
       end
 
       def outcomes
-        flow_input.outcomes.map { |i| interpret_node(i) }
+        flow_input.outcomes.map { |outcome_data| interpret_node(outcome_data) }
       end
 
       def interpret_node(input_data)

--- a/lib/smartdown/parser/input_set.rb
+++ b/lib/smartdown/parser/input_set.rb
@@ -1,0 +1,28 @@
+module Smartdown
+  module Parser
+    class InputSet
+      attr_reader :coversheet, :questions, :outcomes, :snippets, :scenarios
+
+      def initialize(params = {})
+        @coversheet = params[:coversheet]
+        @questions = params[:questions]
+        @outcomes = params[:outcomes]
+        @snippets = params[:snippets]
+        @scenarios = params[:scenarios]
+      end
+    end
+
+    class InputData
+      attr_reader :name, :content
+
+      def initialize(name, content)
+        @name = name
+        @content = content
+      end
+
+      def read
+        content
+      end
+    end
+  end
+end

--- a/lib/smartdown/parser/node_parser.rb
+++ b/lib/smartdown/parser/node_parser.rb
@@ -30,7 +30,7 @@ module Smartdown
       }
 
       rule(:body) {
-        markdown_blocks.as(:body)
+        markdown_blocks.as(:body) >> newline.repeat
       }
 
       rule(:flow) {

--- a/lib/smartdown/parser/snippet_pre_parser.rb
+++ b/lib/smartdown/parser/snippet_pre_parser.rb
@@ -3,6 +3,8 @@ require 'smartdown/parser/input_set'
 module Smartdown
   module Parser
     class SnippetPreParser
+      class SnippetNotFound < StandardError; end
+
       attr_reader :input_data
 
       def initialize(input_data)
@@ -35,7 +37,7 @@ module Smartdown
       end
 
       def get_snippet(snippet_name)
-        input_data.snippets.find { |snippet| snippet.name == snippet_name }
+        input_data.snippets.find { |snippet| snippet.name == snippet_name } or raise SnippetNotFound.new(snippet_name)
       end
     end
   end

--- a/lib/smartdown/parser/snippet_pre_parser.rb
+++ b/lib/smartdown/parser/snippet_pre_parser.rb
@@ -32,7 +32,7 @@ module Smartdown
 
       def parse_content(content)
         content.gsub(/\{\{(.*)\}\}/) { |_|
-          parse_content(get_snippet($1).read)
+          parse_content(get_snippet($1).read.strip)
         }
       end
 

--- a/lib/smartdown/parser/snippet_pre_parser.rb
+++ b/lib/smartdown/parser/snippet_pre_parser.rb
@@ -1,0 +1,42 @@
+require 'smartdown/parser/input_set'
+
+module Smartdown
+  module Parser
+    class SnippetPreParser
+      attr_reader :input_data
+
+      def initialize(input_data)
+        @input_data = input_data
+      end
+
+      def parse
+        InputSet.new({
+          coversheet: parse_node_input(input_data.coversheet),
+          questions: input_data.questions.map { |question_data| parse_node_input(question_data) },
+          outcomes: input_data.outcomes.map { |outcome_data| parse_node_input(outcome_data) },
+          snippets: input_data.snippets,
+          scenarios: input_data.scenarios,
+        })
+      end
+
+      def self.parse(input_data)
+        self.new(input_data).parse
+      end
+
+    private
+      def parse_node_input(node_input)
+        InputData.new(node_input.name, parse_content(node_input.read))
+      end
+
+      def parse_content(content)
+        content.gsub(/\{\{(.*)\}\}/) { |_|
+          parse_content(get_snippet($1).read)
+        }
+      end
+
+      def get_snippet(snippet_name)
+        input_data.snippets.find { |snippet| snippet.name == snippet_name }
+      end
+    end
+  end
+end

--- a/lib/smartdown/parser/snippet_pre_parser.rb
+++ b/lib/smartdown/parser/snippet_pre_parser.rb
@@ -31,7 +31,7 @@ module Smartdown
       end
 
       def parse_content(content)
-        content.gsub(/\{\{(.*)\}\}/) { |_|
+        content.gsub(/\{\{snippet:\W?(.*)\}\}/i) { |_|
           parse_content(get_snippet($1).read.strip)
         }
       end

--- a/spec/acceptance/parsing_spec.rb
+++ b/spec/acceptance/parsing_spec.rb
@@ -112,6 +112,14 @@ EXPECTED
       expect(flow.instance_of? Smartdown::Model::Flow).to eq(true)
     end
   end
+
+  context "snippets" do
+    subject(:flow) { Smartdown.parse(fixture("snippet")) }
+
+    it "has replaced the snippet tag with the snippet contents" do
+      expect(flow.nodes.first.elements.any? { |element| element.content.to_s.include? "snippet body" })
+    end
+  end
 end
 
 

--- a/spec/fixtures/acceptance/snippet/snippet.txt
+++ b/spec/fixtures/acceptance/snippet/snippet.txt
@@ -1,0 +1,7 @@
+meta_description: Snippets
+satisfies_need: 999999
+status: draft
+
+# A snippet in use
+
+{{snippet: the_snippet}}

--- a/spec/fixtures/acceptance/snippet/snippets/the_snippet.txt
+++ b/spec/fixtures/acceptance/snippet/snippets/the_snippet.txt
@@ -1,0 +1,1 @@
+snippet body

--- a/spec/fixtures/directory_input/snippets/sn1.txt
+++ b/spec/fixtures/directory_input/snippets/sn1.txt
@@ -1,0 +1,1 @@
+snippet one

--- a/spec/parser/directory_input_spec.rb
+++ b/spec/parser/directory_input_spec.rb
@@ -1,11 +1,5 @@
 require 'smartdown/parser/directory_input'
-
-shared_examples "flow input interface" do
-  it { should respond_to(:coversheet) }
-  it { should respond_to(:questions) }
-  it { should respond_to(:outcomes) }
-  it { should respond_to(:scenarios) }
-end
+require 'support/flow_input_interface'
 
 describe Smartdown::Parser::DirectoryInput do
   it_should_behave_like "flow input interface"
@@ -51,6 +45,14 @@ describe Smartdown::Parser::DirectoryInput do
       expect(input.scenarios).to match([instance_of(Smartdown::Parser::InputFile)])
       expect(input.scenarios.first.name).to eq("s1")
       expect(input.scenarios.first.read).to eq("scenario one\n")
+    end
+  end
+
+  describe "#snippets" do
+    it "returns an InputFile for every file in the snippets folder" do
+      expect(input.snippets).to match([instance_of(Smartdown::Parser::InputFile)])
+      expect(input.snippets.first.name).to eq("sn1")
+      expect(input.snippets.first.read).to eq("snippet one\n")
     end
   end
 end

--- a/spec/parser/input_set_spec.rb
+++ b/spec/parser/input_set_spec.rb
@@ -1,0 +1,15 @@
+require 'smartdown/parser/input_set'
+require 'support/flow_input_interface'
+
+describe Smartdown::Parser::InputSet do
+  it_should_behave_like "flow input interface"
+end
+
+describe Smartdown::Parser::InputData do
+  let(:name) { 'a name' }
+  let(:data) { 'some smartdown' }
+  subject { Smartdown::Parser::InputData.new(name, data) }
+
+  specify { expect(subject.name).to eql name }
+  specify { expect(subject.read).to eql data }
+end

--- a/spec/parser/node_parser_spec.rb
+++ b/spec/parser/node_parser_spec.rb
@@ -166,4 +166,30 @@ SOURCE
       })
     }
   end
+
+  context "body with extra trailing newlines" do
+    let(:source) {
+<<SOURCE
+# This is my title
+
+This is a paragraph of text with stuff
+that flows along
+
+Another paragraph of text
+
+
+SOURCE
+     }
+
+    it {
+      should parse(source).as({
+        body: [
+          {h1: "This is my title"},
+          {p: "This is a paragraph of text with stuff\nthat flows along\n"},
+          {p: "Another paragraph of text\n"}
+        ]
+      })
+    }
+  end
+
 end

--- a/spec/parser/snippet_pre_parser_spec.rb
+++ b/spec/parser/snippet_pre_parser_spec.rb
@@ -1,0 +1,58 @@
+require 'smartdown/parser/snippet_pre_parser'
+require 'smartdown/parser/directory_input'
+require 'ostruct'
+
+describe Smartdown::Parser::SnippetPreParser do
+  let(:input_data) {
+    Smartdown::Parser::InputSet.new({
+      coversheet: Smartdown::Parser::InputData.new("coversheet_1", "some smartdown {{coversheet_snippet}}"),
+      questions: [
+        Smartdown::Parser::InputData.new("question_1", "some {{question_snippet}} smartdown"),
+      ],
+      outcomes: [
+        Smartdown::Parser::InputData.new("outcome_1", "some smartdown\n\n{{outcome_snippet}}\n\nmore smartdown"),
+      ],
+      snippets: [
+        Smartdown::Parser::InputData.new("question_snippet", "question snippet"),
+        Smartdown::Parser::InputData.new("outcome_snippet", "outcome snippet"),
+        Smartdown::Parser::InputData.new("coversheet_snippet", "coversheet snippet"),
+      ],
+      scenarios: [:some_scenario]
+    })
+  }
+
+  subject(:parsed_output) {
+    described_class.parse(input_data)
+  }
+
+  it "should replace the snippet tag with the snippet content for questions" do
+    expect(parsed_output.questions[0].read).to eql "some question snippet smartdown"
+  end
+
+  it "should replace the snippet tag with the snippet content for outcomes" do
+    expect(parsed_output.outcomes[0].read).to eql "some smartdown\n\noutcome snippet\n\nmore smartdown"
+  end
+
+  it "should replace the snippet tag with the snippet content for the coversheet" do
+    expect(parsed_output.coversheet.read).to eql "some smartdown coversheet snippet"
+  end
+
+  context "with nested snippets" do
+    let(:input_data) {
+      Smartdown::Parser::InputSet.new({
+        coversheet: Smartdown::Parser::InputData.new("coversheet_1", "some smartdown {{top_level_snippet}}"),
+        questions: [],
+        outcomes: [],
+        snippets: [
+          Smartdown::Parser::InputData.new("top_level_snippet", "top level snippet {{nested_snippet}}"),
+          Smartdown::Parser::InputData.new("nested_snippet", "nested snippet"),
+        ],
+        scenarios: []
+      })
+    }
+
+    it "shoud recursively process nested snippets" do
+      expect(parsed_output.coversheet.read).to eql "some smartdown top level snippet nested snippet"
+    end
+  end
+end

--- a/spec/parser/snippet_pre_parser_spec.rb
+++ b/spec/parser/snippet_pre_parser_spec.rb
@@ -5,12 +5,12 @@ require 'ostruct'
 describe Smartdown::Parser::SnippetPreParser do
   let(:input_data) {
     Smartdown::Parser::InputSet.new({
-      coversheet: Smartdown::Parser::InputData.new("coversheet_1", "some smartdown {{coversheet_snippet}}"),
+      coversheet: Smartdown::Parser::InputData.new("coversheet_1", "some smartdown {{snippet: coversheet_snippet}}"),
       questions: [
-        Smartdown::Parser::InputData.new("question_1", "some {{question_snippet}} smartdown"),
+        Smartdown::Parser::InputData.new("question_1", "some {{snippet: question_snippet}} smartdown"),
       ],
       outcomes: [
-        Smartdown::Parser::InputData.new("outcome_1", "some smartdown\n\n{{outcome_snippet}}\n\nmore smartdown"),
+        Smartdown::Parser::InputData.new("outcome_1", "some smartdown\n\n{{snippet: outcome_snippet}}\n\nmore smartdown"),
       ],
       snippets: [
         Smartdown::Parser::InputData.new("question_snippet", "question snippet"),
@@ -40,11 +40,11 @@ describe Smartdown::Parser::SnippetPreParser do
   context "with nested snippets" do
     let(:input_data) {
       Smartdown::Parser::InputSet.new({
-        coversheet: Smartdown::Parser::InputData.new("coversheet_1", "some smartdown {{top_level_snippet}}"),
+        coversheet: Smartdown::Parser::InputData.new("coversheet_1", "some smartdown {{snippet: top_level_snippet}}"),
         questions: [],
         outcomes: [],
         snippets: [
-          Smartdown::Parser::InputData.new("top_level_snippet", "top level snippet {{nested_snippet}}"),
+          Smartdown::Parser::InputData.new("top_level_snippet", "top level snippet {{snippet: nested_snippet}}"),
           Smartdown::Parser::InputData.new("nested_snippet", "nested snippet"),
         ],
         scenarios: []
@@ -59,7 +59,7 @@ describe Smartdown::Parser::SnippetPreParser do
   context "when referencing a non-existent snippet" do
     let(:input_data) {
       Smartdown::Parser::InputSet.new({
-        coversheet: Smartdown::Parser::InputData.new("coversheet_1", "some smartdown {{non_existent_snippet}}"),
+        coversheet: Smartdown::Parser::InputData.new("coversheet_1", "some smartdown {{snippet: non_existent_snippet}}"),
         questions: [],
         outcomes: [],
         snippets: [],
@@ -74,7 +74,7 @@ describe Smartdown::Parser::SnippetPreParser do
     let(:snippet_smartdown) { "A snippet" }
     let(:input_data) {
       Smartdown::Parser::InputSet.new({
-        coversheet: Smartdown::Parser::InputData.new("coversheet_1",  "Smartdown {{snippet}} more smartdown"),
+        coversheet: Smartdown::Parser::InputData.new("coversheet_1",  "Smartdown {{snippet: snippet}} more smartdown"),
         questions: [],
         outcomes: [],
         snippets: [ Smartdown::Parser::InputData.new("snippet", snippet_smartdown) ],
@@ -88,6 +88,29 @@ describe Smartdown::Parser::SnippetPreParser do
       it "should strip off the snippet content's leading and trailing whitespace" do
         expect(parsed_output.coversheet.read).to eql "Smartdown Snippet text\n\n with whitespace more smartdown"
       end
+    end
+  end
+
+  describe "alternative tag definitions" do
+    let(:snippet_tag) { "{{snippet: snippet_name}}" }
+    let(:input_data) {
+      Smartdown::Parser::InputSet.new({
+        coversheet: Smartdown::Parser::InputData.new("coversheet_1",  snippet_tag),
+        questions: [],
+        outcomes: [],
+        snippets: [ Smartdown::Parser::InputData.new("snippet_name", "the snippet") ],
+        scenarios: []
+      })
+    }
+
+    context "with {{SNIPPET: snippet_name}}" do
+      let(:snippet_tag) { "{{SNIPPET: snippet_name}}" }
+      specify { expect(parsed_output.coversheet.read).to eql "the snippet" }
+    end
+
+    context "with {{snippet:snippet_name}}" do
+      let(:snippet_tag) { "{{snippet:snippet_name}}" }
+      specify { expect(parsed_output.coversheet.read).to eql "the snippet" }
     end
   end
 end

--- a/spec/parser/snippet_pre_parser_spec.rb
+++ b/spec/parser/snippet_pre_parser_spec.rb
@@ -55,4 +55,18 @@ describe Smartdown::Parser::SnippetPreParser do
       expect(parsed_output.coversheet.read).to eql "some smartdown top level snippet nested snippet"
     end
   end
+
+  context "when referencing a non-existent snippet" do
+    let(:input_data) {
+      Smartdown::Parser::InputSet.new({
+        coversheet: Smartdown::Parser::InputData.new("coversheet_1", "some smartdown {{non_existent_snippet}}"),
+        questions: [],
+        outcomes: [],
+        snippets: [],
+        scenarios: []
+      })
+    }
+
+    specify { expect { parsed_output }.to raise_exception(Smartdown::Parser::SnippetPreParser::SnippetNotFound) }
+  end
 end

--- a/spec/parser/snippet_pre_parser_spec.rb
+++ b/spec/parser/snippet_pre_parser_spec.rb
@@ -69,4 +69,25 @@ describe Smartdown::Parser::SnippetPreParser do
 
     specify { expect { parsed_output }.to raise_exception(Smartdown::Parser::SnippetPreParser::SnippetNotFound) }
   end
+
+  describe "whitespace handling" do
+    let(:snippet_smartdown) { "A snippet" }
+    let(:input_data) {
+      Smartdown::Parser::InputSet.new({
+        coversheet: Smartdown::Parser::InputData.new("coversheet_1",  "Smartdown {{snippet}} more smartdown"),
+        questions: [],
+        outcomes: [],
+        snippets: [ Smartdown::Parser::InputData.new("snippet", snippet_smartdown) ],
+        scenarios: []
+      })
+    }
+
+    context "when snippet smartdown has leading / trailing whitespace" do
+      let(:snippet_smartdown) { "\n\n  Snippet text\n\n with whitespace  \n\n" }
+
+      it "should strip off the snippet content's leading and trailing whitespace" do
+        expect(parsed_output.coversheet.read).to eql "Smartdown Snippet text\n\n with whitespace more smartdown"
+      end
+    end
+  end
 end

--- a/spec/support/flow_input_interface.rb
+++ b/spec/support/flow_input_interface.rb
@@ -1,0 +1,7 @@
+shared_examples "flow input interface" do
+  it { should respond_to(:coversheet) }
+  it { should respond_to(:questions) }
+  it { should respond_to(:outcomes) }
+  it { should respond_to(:scenarios) }
+  it { should respond_to(:snippets) }
+end


### PR DESCRIPTION
Add the ability to use snippets in smartdown

Snippets are defined in text files in the `snippets` folder of a smartdown flow. They can then be inserted into any smartdown content with this:

```
{{snippet_filename_without_extension}}
```

These are pre-parsed before reaching the main parser.
