### PR TITLE
PreviousQuestionPage title and whitespace bugfixes

### DIFF
--- a/lib/smartdown/api/node.rb
+++ b/lib/smartdown/api/node.rb
@@ -53,7 +53,8 @@ module Smartdown
         markdown_elements = elements.select do |element|
           markdown_element?(element)
         end
-        GovspeakPresenter.new(markdown_elements.map(&:content).join("\n")).html
+        govspeak = markdown_elements.map(&:content).join("\n")
+        GovspeakPresenter.new(govspeak).html unless govspeak.empty?
       end
     end
   end

--- a/lib/smartdown/api/previous_question_page.rb
+++ b/lib/smartdown/api/previous_question_page.rb
@@ -11,12 +11,12 @@ module Smartdown
         headings = node_elements.select {
           |element| element.is_a? Smartdown::Model::Element::MarkdownHeading
         }
-        @title = headings.first.content.to_s if headings.first
         nb_questions = node_elements.select{ |element|
           element.class.to_s.include?("Smartdown::Model::Element::Question")
         }.count
         if headings.count > nb_questions
           node_elements.delete(headings.first) #Remove page title
+          @title = headings.first.content.to_s
         end
         @elements = node_elements
         @responses = responses

--- a/lib/smartdown/api/question.rb
+++ b/lib/smartdown/api/question.rb
@@ -35,7 +35,8 @@ module Smartdown
         markdown_elements = elements.select do |element|
           markdown_element?(element)
         end
-        GovspeakPresenter.new(markdown_elements.map(&:content).join("\n")).html
+        govspeak = markdown_elements.map(&:content).join("\n")
+        GovspeakPresenter.new(govspeak).html unless govspeak.empty?
       end
     end
   end


### PR DESCRIPTION
- There should only be a previous question page title if there are more headings than questions, which is the same logic as in question.
- Parsing empty input in govspeak was returning expected results, which was breaking the task which compares (via diff) smartdown flows vs smart answer flows
