### PR TITLE
[merge first] Change Answer object API: question not necessary

### DIFF
--- a/lib/smartdown/engine.rb
+++ b/lib/smartdown/engine.rb
@@ -35,7 +35,7 @@ module Smartdown
           transition = Transition.new(state, current_node, unprocessed_responses.shift(1))
         else
           answers = current_node.questions.map do |question|
-            question.answer_type.new(question, unprocessed_responses.shift)
+            question.answer_type.new(unprocessed_responses.shift, question)
           end
 
           transition = Transition.new(state, current_node, answers)

--- a/lib/smartdown/model/answer/base.rb
+++ b/lib/smartdown/model/answer/base.rb
@@ -17,9 +17,9 @@ module Smartdown
 
         attr_reader :question, :value
 
-        def initialize(question, value)
-          @question = question
+        def initialize(value, question=nil)
           @value = parse_value(value)
+          @question = question
         end
 
       private

--- a/spec/engine/interpolator_spec.rb
+++ b/spec/engine/interpolator_spec.rb
@@ -4,6 +4,7 @@ require 'smartdown/model/answer/money'
 require 'smartdown/engine/interpolator'
 require 'smartdown/engine/state'
 require 'parslet'
+require 'date'
 
 describe Smartdown::Engine::Interpolator do
   subject(:interpolator) { described_class.new }
@@ -116,7 +117,7 @@ describe Smartdown::Engine::Interpolator do
     let(:state) {
       Smartdown::Engine::State.new(
           current_node: node.name,
-          date_answer: Smartdown::Model::Answer::Date.new("date_question", "2014-1-1")
+          date_answer: Smartdown::Model::Answer::Date.new("2014-1-1")
       )
     }
     it "interpolates the result of the function call" do
@@ -129,7 +130,7 @@ describe Smartdown::Engine::Interpolator do
     let(:state) {
       Smartdown::Engine::State.new(
           current_node: node.name,
-          money_answer: Smartdown::Model::Answer::Money.new("money_answer", 12.32523)
+          money_answer: Smartdown::Model::Answer::Money.new(12.32523)
       )
     }
     it "interpolates the result of the function call" do

--- a/spec/model/answer/base_spec.rb
+++ b/spec/model/answer/base_spec.rb
@@ -4,7 +4,7 @@ describe Smartdown::Model::Answer::Base do
   let(:question) { :a_question }
   let(:value) { 'a value' }
 
-  subject(:instance) {Smartdown::Model::Answer::Base.new(question, value)}
+  subject(:instance) {Smartdown::Model::Answer::Base.new(value, question)}
 
   specify { expect(instance.question).to eql question }
 

--- a/spec/model/answer/date_spec.rb
+++ b/spec/model/answer/date_spec.rb
@@ -4,7 +4,7 @@ require 'smartdown/model/element/question/date'
 describe Smartdown::Model::Answer::Date do
   let(:date_string) { "2014-9-4" }
   let(:question) { Smartdown::Model::Element::Question::Date.new("a_date") }
-  subject(:instance) { described_class.new(question, date_string) }
+  subject(:instance) { described_class.new(date_string, question) }
 
   specify { expect(instance.value).to eql Date.new(2014, 9, 4) }
   specify { expect(instance.to_s).to eql "2014-9-4" }
@@ -59,23 +59,23 @@ describe Smartdown::Model::Answer::Date do
     end
 
     context "comparing against Answer::Dates" do
-      specify { expect(instance == described_class.new(nil, "2000-1-10")).to eql true }
+      specify { expect(instance == described_class.new("2000-1-10")).to eql true }
 
-      specify { expect(instance < described_class.new(nil, "2000-1-11")).to eql true }
-      specify { expect(instance < described_class.new(nil, "2000-1-10")).to eql false }
-      specify { expect(instance < described_class.new(nil, "2000-1-9")).to eql false }
+      specify { expect(instance < described_class.new("2000-1-11")).to eql true }
+      specify { expect(instance < described_class.new("2000-1-10")).to eql false }
+      specify { expect(instance < described_class.new("2000-1-9")).to eql false }
 
-      specify { expect(instance > described_class.new(nil, "2000-1-11")).to eql false }
-      specify { expect(instance > described_class.new(nil, "2000-1-10")).to eql false }
-      specify { expect(instance > described_class.new(nil, "2000-1-9")).to eql true }
+      specify { expect(instance > described_class.new("2000-1-11")).to eql false }
+      specify { expect(instance > described_class.new("2000-1-10")).to eql false }
+      specify { expect(instance > described_class.new("2000-1-9")).to eql true }
 
-      specify { expect(instance <= described_class.new(nil, "2000-1-11")).to eql true }
-      specify { expect(instance <= described_class.new(nil, "2000-1-10")).to eql true }
-      specify { expect(instance <= described_class.new(nil, "2000-1-9")).to eql false }
+      specify { expect(instance <= described_class.new("2000-1-11")).to eql true }
+      specify { expect(instance <= described_class.new("2000-1-10")).to eql true }
+      specify { expect(instance <= described_class.new("2000-1-9")).to eql false }
 
-      specify { expect(instance >= described_class.new(nil, "2000-1-11")).to eql false }
-      specify { expect(instance >= described_class.new(nil, "2000-1-10")).to eql true }
-      specify { expect(instance >= described_class.new(nil, "2000-1-9")).to eql true }
+      specify { expect(instance >= described_class.new("2000-1-11")).to eql false }
+      specify { expect(instance >= described_class.new("2000-1-10")).to eql true }
+      specify { expect(instance >= described_class.new("2000-1-9")).to eql true }
     end
   end
 end

--- a/spec/model/answer/money_spec.rb
+++ b/spec/model/answer/money_spec.rb
@@ -4,7 +4,7 @@ require 'smartdown/model/answer/money'
 describe Smartdown::Model::Answer::Money do
 
   let(:money_float) { 523.42 }
-  subject(:instance) { described_class.new(nil, money_float) }
+  subject(:instance) { described_class.new(money_float) }
 
   describe "#humanize" do
     it "specifies money in the correct format" do

--- a/spec/model/answer/salary_spec.rb
+++ b/spec/model/answer/salary_spec.rb
@@ -4,7 +4,7 @@ require 'smartdown/model/element/question/date'
 describe Smartdown::Model::Answer::Salary do
   let(:salary_string) { "500-week" }
   let(:question) { Smartdown::Model::Element::Question::Date.new("a_date") }
-  subject(:instance) { described_class.new(question, salary_string) }
+  subject(:instance) { described_class.new(salary_string, question) }
 
   specify { expect(instance.period).to eql('week') }
   specify { expect(instance.amount_per_period).to eql(500.00) }
@@ -76,23 +76,23 @@ describe Smartdown::Model::Answer::Salary do
     end
 
     context "comparing against Answer::Salaries" do
-      specify { expect(instance == described_class.new(nil, "1200-week")).to eql true }
+      specify { expect(instance == described_class.new("1200-week")).to eql true }
 
-      specify { expect(instance < described_class.new(nil, "1200.1-week")).to eql true }
-      specify { expect(instance < described_class.new(nil, "1200.0-week")).to eql false }
-      specify { expect(instance < described_class.new(nil, "1199.9-week")).to eql false }
+      specify { expect(instance < described_class.new("1200.1-week")).to eql true }
+      specify { expect(instance < described_class.new("1200.0-week")).to eql false }
+      specify { expect(instance < described_class.new("1199.9-week")).to eql false }
 
-      specify { expect(instance > described_class.new(nil, "1200.1-week")).to eql false }
-      specify { expect(instance > described_class.new(nil, "1200.0-week")).to eql false }
-      specify { expect(instance > described_class.new(nil, "1199.9-week")).to eql true }
+      specify { expect(instance > described_class.new("1200.1-week")).to eql false }
+      specify { expect(instance > described_class.new("1200.0-week")).to eql false }
+      specify { expect(instance > described_class.new("1199.9-week")).to eql true }
 
-      specify { expect(instance <= described_class.new(nil, "1200.1-week")).to eql true }
-      specify { expect(instance <= described_class.new(nil, "1200.0-week")).to eql true }
-      specify { expect(instance <= described_class.new(nil, "1199.9-week")).to eql false }
+      specify { expect(instance <= described_class.new("1200.1-week")).to eql true }
+      specify { expect(instance <= described_class.new("1200.0-week")).to eql true }
+      specify { expect(instance <= described_class.new("1199.9-week")).to eql false }
 
-      specify { expect(instance >= described_class.new(nil, "1200.1-week")).to eql false }
-      specify { expect(instance >= described_class.new(nil, "1200.0-week")).to eql true }
-      specify { expect(instance >= described_class.new(nil, "1199.9-week")).to eql true }
+      specify { expect(instance >= described_class.new("1200.1-week")).to eql false }
+      specify { expect(instance >= described_class.new("1200.0-week")).to eql true }
+      specify { expect(instance >= described_class.new("1199.9-week")).to eql true }
     end
   end
 end


### PR DESCRIPTION
Interface change for initialization of an Answer object: this allows for use of the Answer object from plugins without having to specify a question name. 
