### PR TITLE
Allow functions to have a ? suffix, ruby style

### DIFF
--- a/lib/smartdown/parser/predicates.rb
+++ b/lib/smartdown/parser/predicates.rb
@@ -60,7 +60,7 @@ module Smartdown
       }
 
       rule (:function_predicate) {
-        identifier.as(:name) >>
+        (identifier >> str('?').maybe).as(:name) >>
         str('(') >>
         function_arguments.as(:arguments).maybe >>
         str(')')

--- a/spec/model/predicates/function_spec.rb
+++ b/spec/model/predicates/function_spec.rb
@@ -45,6 +45,17 @@ describe Smartdown::Model::Predicate::Function do
       end
     end
 
+    context "with a ? in the function name" do
+      let(:function_name) { "is_odd?" }
+      let(:my_function) { ->(number) { number.odd? } }
+      subject(:predicate) { described_class.new(function_name, ["number"]) }
+      let(:state) { Smartdown::Engine::State.new(current_node: "n", "number" => 3, function_name => my_function) }
+
+      it "can be called normally" do
+        expect(predicate.evaluate(state)).to eq(true)
+      end
+    end
+
     context "with nested functions" do
       # nesting looks like: function_1(function_2(5))
       let(:function_1) { ->(x) { x - 1 } }

--- a/spec/parser/predicates_spec.rb
+++ b/spec/parser/predicates_spec.rb
@@ -140,6 +140,21 @@ describe Smartdown::Parser::Predicates do
       end
     end
 
+    context "with ? in name" do
+      let(:source) { "function_name?()" }
+
+      it { should parse(source).as(function_predicate: { name: "function_name?" }) }
+
+      describe "transformed" do
+        let(:node_name) { "my_node" }
+        subject(:transformed) {
+          Smartdown::Parser::NodeInterpreter.new(node_name, source, parser: parser).interpret
+        }
+
+        it { should eq(Smartdown::Model::Predicate::Function.new("function_name?", [])) }
+      end
+    end
+
     context "single argument" do
       let(:source) { "function_name(arg_1)" }
 


### PR DESCRIPTION
Implemented after suggestion in https://www.agileplannerapp.com/boards/105200/cards/7873

I'm not sure if this is a good idea for Smartdown, but i figured it was easier to
discuss with a working code example.

Good: Familiar to ruby devs, allows plugin defs in ruby to use normal naming
Bad: A little confusing in smartdown, as trailing ? has semantics for a named predicate

CC @jackscotti and @camilleldn, also of interest to @karlentwistle and @FriedSock 
