### PR TITLE
Don't expose Parselet::Slice to Models

### DIFF
--- a/lib/smartdown/parser/node_transform.rb
+++ b/lib/smartdown/parser/node_transform.rb
@@ -33,15 +33,15 @@ module Smartdown
       }
 
       rule(h1: simple(:content)) {
-        Smartdown::Model::Element::MarkdownHeading.new(content)
+        Smartdown::Model::Element::MarkdownHeading.new(content.to_s)
       }
 
       rule(p: simple(:content)) {
-        Smartdown::Model::Element::MarkdownParagraph.new(content)
+        Smartdown::Model::Element::MarkdownParagraph.new(content.to_s)
       }
 
       rule(:start_button => simple(:start_node)) {
-        Smartdown::Model::Element::StartButton.new(start_node)
+        Smartdown::Model::Element::StartButton.new(start_node.to_s)
       }
 
       rule(:front_matter => subtree(:attrs), body: subtree(:body)) {
@@ -66,7 +66,7 @@ module Smartdown
 
       rule(:multiple_choice => {identifier: simple(:identifier), options: subtree(:choices)}) {
         Smartdown::Model::Element::Question::MultipleChoice.new(
-          identifier, Hash[choices]
+          identifier.to_s, Hash[choices]
         )
       }
 
@@ -115,17 +115,17 @@ module Smartdown
       }
 
       rule(:equality_predicate => { varname: simple(:varname), expected_value: simple(:expected_value) }) {
-        Smartdown::Model::Predicate::Equality.new(varname, expected_value)
+        Smartdown::Model::Predicate::Equality.new(varname.to_s, expected_value.to_s)
       }
 
       rule(:set_value => simple(:value)) { value }
 
       rule(:set_membership_predicate => { varname: simple(:varname), values: subtree(:values) }) {
-        Smartdown::Model::Predicate::SetMembership.new(varname, values)
+        Smartdown::Model::Predicate::SetMembership.new(varname.to_s, values)
       }
 
       rule(:named_predicate => simple(:name) ) {
-        Smartdown::Model::Predicate::Named.new(name)
+        Smartdown::Model::Predicate::Named.new(name.to_s)
       }
 
       rule(:otherwise_predicate => simple(:name) ) {
@@ -136,14 +136,14 @@ module Smartdown
         Smartdown::Model::Predicate::Combined.new([first_predicate]+and_predicates)
       }
 
-      rule(:function_argument => simple(:argument)) { argument }
+      rule(:function_argument => simple(:argument)) { argument.to_s }
 
       rule(:function_predicate => { name: simple(:name), arguments: subtree(:arguments) }) {
-        Smartdown::Model::Predicate::Function.new(name, Array(arguments))
+        Smartdown::Model::Predicate::Function.new(name.to_s, Array(arguments))
       }
 
       rule(:function_predicate => { name: simple(:name) }) {
-        Smartdown::Model::Predicate::Function.new(name, [])
+        Smartdown::Model::Predicate::Function.new(name.to_s, [])
       }
 
       rule(:comparison_predicate => { varname: simple(:varname), 
@@ -152,20 +152,20 @@ module Smartdown
                                      }) { 
         case operator
         when "<="
-          Smartdown::Model::Predicate::Comparison::LessOrEqual.new(varname, value)
+          Smartdown::Model::Predicate::Comparison::LessOrEqual.new(varname.to_s, value.to_s)
         when "<"
-          Smartdown::Model::Predicate::Comparison::Less.new(varname, value)
+          Smartdown::Model::Predicate::Comparison::Less.new(varname.to_s, value.to_s)
         when ">="
-          Smartdown::Model::Predicate::Comparison::GreaterOrEqual.new(varname, value)
+          Smartdown::Model::Predicate::Comparison::GreaterOrEqual.new(varname.to_s, value.to_s)
         when ">"
-          Smartdown::Model::Predicate::Comparison::Greater.new(varname, value)
+          Smartdown::Model::Predicate::Comparison::Greater.new(varname.to_s, value.to_s)
         else
           raise "Comparison operator not recognised"
         end
       }
 
       rule(:rule => {predicate: subtree(:predicate), outcome: simple(:outcome_name) } ) {
-        Smartdown::Model::Rule.new(predicate, outcome_name)
+        Smartdown::Model::Rule.new(predicate, outcome_name.to_s)
       }
       rule(:nested_rule => {predicate: subtree(:predicate), child_rules: subtree(:child_rules) } ) {
         Smartdown::Model::NestedRule.new(predicate, child_rules)

--- a/spec/engine/interpolator_spec.rb
+++ b/spec/engine/interpolator_spec.rb
@@ -72,17 +72,6 @@ describe Smartdown::Engine::Interpolator do
     end
   end
 
-  context "a paragraph containing a parslet slice" do
-    let(:elements) { [Smartdown::Model::Element::MarkdownParagraph.new(Parslet::Slice.new(0, 'Hello %{name}'))] }
-
-    it "interpolates without raising an error about gsub missing" do
-      # Note: the parser actually produces parslet 'slices' rather than strings.
-      # A parslet slice behaves like a string but doesn't have all of the methods of string.
-      # This test is to document that fact and catch any regressions.
-      expect(interpolated_node.elements.first.content).to eq("Hello #{example_name}")
-    end
-  end
-
   context "a paragraph containing function call" do
     let(:elements) { [Smartdown::Model::Element::MarkdownParagraph.new('%{double(number)}')] }
     let(:state) {


### PR DESCRIPTION
This is some techdebt cleanup, occasionally Slice strings surface unexpectedly and cause problems. 

Slices are like regular strings, except;
- they remember where they were in the original string
- they don't implement all string methods

See: http://www.rubydoc.info/github/kschiess/parslet/Parslet/Slice

As we don't rely on the original position information and any Smartdown
model can be constructed manually, or potentially by another parser
they shouldn't need to be aware of Slices at all.

Cast all Slices to strings during transformation. Remove a model test
that expected slices, as it's not needed anymore
