### PR TITLE
Output line number and column number of syntax error

### DIFF
--- a/lib/smartdown/parser/flow_interpreter.rb
+++ b/lib/smartdown/parser/flow_interpreter.rb
@@ -13,7 +13,11 @@ module Smartdown
       end
 
       def to_s(full = true)
-        "Parse error in '#{filename}':\n\n" + @parse_error.cause.ascii_tree
+        position = parse_error.cause.pos
+        line, column = parse_error.cause.source.line_and_column(position)
+
+        "Parse error in file:'#{filename}' line:'#{line}' column:'#{column}'" +
+        "\n\n" + parse_error.cause.ascii_tree
       end
     end
 

--- a/lib/smartdown/parser/node_interpreter.rb
+++ b/lib/smartdown/parser/node_interpreter.rb
@@ -7,7 +7,7 @@ require 'smartdown/parser/node_transform'
 module Smartdown
   module Parser
     class NodeInterpreter
-      attr_reader :name, :source
+      attr_reader :name, :source, :reporter
 
       def initialize(name, source, options = {})
         @name = name
@@ -15,10 +15,11 @@ module Smartdown
         data_module = options.fetch(:data_module, {})
         @parser = options.fetch(:parser, Smartdown::Parser::NodeParser.new)
         @transform = options.fetch(:transform, Smartdown::Parser::NodeTransform.new(data_module))
+        @reporter = options.fetch(:reporter, Parslet::ErrorReporter::Deepest.new)
       end
 
       def interpret
-        transform.apply(parser.parse(source),
+        transform.apply(parser.parse(source, reporter: reporter),
           node_name: name
         )
       end


### PR DESCRIPTION
## Agile Planner Ticket

[Better Smartdown error messages](https://www.agileplannerapp.com/boards/105200/cards/6366)
## What does this do

Previously smartdown output an error message in the form of a filename and asci_tree. Like

```
Parse error in foobar

Expected at least 2 of CALL / ELEMENT at line 1 char 1.
`- Expected one of [CALL, ELEMENT] at line 1 char 4.
   |- Failed to match sequence ('baz' '()') at line 1 char 7.
   |  `- Premature end of input at line 1 char 7.
   `- Expected "bar", but got "baz" at line 1 char 4.
```

Now it will output filename, line number, column number and the asci_tree

```
Parse error in file:'question_2' line:'9' column:'16'

Expected at least 2 of CALL / ELEMENT at line 1 char 1.
`- Expected one of [CALL, ELEMENT] at line 1 char 4.
   |- Failed to match sequence ('baz' '()') at line 1 char 7.
   |  `- Premature end of input at line 1 char 7.
   `- Premature end of input at line 1 char 7.
```
## Steps to reproduce error

1) Edit the Gemfile in smart-answers so that it uses a local version of smartdown based on the path. By default in the GDS VM this is /var/govuk/smartdown

```
#if ENV['SMARTDOWN_DEV']
  gem 'smartdown', :path => '../smartdown'
#else
#  gem 'smartdown', '0.8.2'
#end
```

2) Checkout this branch (better_errors) in smartdown
3) Bundle!!!
4) bowl smart-answers
5) Edit one of the example smartdown_flows animal-example-multiple or animal-example-simple with a syntax error. I used

```
# Are you trained for lions?

[choice: trained_for_lions]
* yes: Yes
* no: No

* type_of_feline is 'lion'
  * trained_for_lions is 'yes' => outcome_trained_with_lions
  * otherwisez => question_3
* otherwise => outcome_tigers_are_fine
```

Note the mistake i've made of using otherwisez and not otherwise

Now navigate to the flow and check that the 'headline' of the error message is pointing at the correct filename and line and column
