### PR TITLE
Don't humanize strings

### DIFF
--- a/lib/smartdown/engine/interpolator.rb
+++ b/lib/smartdown/engine/interpolator.rb
@@ -41,7 +41,10 @@ module Smartdown
         def interpolate(text, state)
           text.to_s.gsub(/%{([^}]+)}/) do |_|
             term = resolve_term($1, state)
-            term.respond_to?(:humanize) ? term.humanize : term
+            if term.respond_to?(:humanize) and !term.is_a?(String)
+              term = term.humanize
+            end
+            term
           end
         end
 

--- a/lib/smartdown/engine/interpolator.rb
+++ b/lib/smartdown/engine/interpolator.rb
@@ -41,7 +41,7 @@ module Smartdown
         def interpolate(text, state)
           text.to_s.gsub(/%{([^}]+)}/) do |_|
             term = resolve_term($1, state)
-            if term.respond_to?(:humanize) and !term.is_a?(String)
+            if term.is_a?(Smartdown::Model::Answer::Base)
               term = term.humanize
             end
             term


### PR DESCRIPTION
Data partials pass back HTML which is getting humanized and breaking the casing in the HTML. This still allows Answer objects to be humanized but will stop data partials getting mangled. Slightly hacky fix, that should be refactored when looking at Answer objects more generally.

If you consider about merging this PR, I will need to add some tests. This is just a demonstration on how to fix the 'issue'.

(paired with @dsingleton )
