### PR TITLE
Date Question Optional Ranges

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,21 @@ country slugs/names.
 [date: baby_due_date]
 ```
 
+To control the range of years selected you can supply 2 optional arguments to date questions: `from` and `to`.
+These can take the form of absolute values, eg.
+
+```markdown
+[date: baby_due_date, from: 2010, to: 2015]
+```
+
+Or relative values (from the current year), eg.
+
+```markdown
+[date: baby_due_date, from: -4, to: 1]
+```
+
+The default values for `from` and `to` are relative years: `-1` and `3` respectively.
+
 ### Text
 
 ```markdown

--- a/lib/smartdown/api/date_question.rb
+++ b/lib/smartdown/api/date_question.rb
@@ -3,6 +3,39 @@ require 'smartdown/api/question'
 module Smartdown
   module Api
     class DateQuestion < Question
+      extend Forwardable
+      DEFAULT_START_YEAR = Time.now.year - 1
+      DEFAULT_END_YEAR = Time.now.year + 3
+
+      def start_year
+        parse_date(from) || DEFAULT_START_YEAR
+      end
+
+      def end_year
+        parse_date(to) || DEFAULT_END_YEAR
+      end
+
+    private
+
+      delegate [:to, :from] => :question_element
+
+      def question_element
+        @question_element ||= elements.find{|element| element.is_a? Smartdown::Model::Element::Question::Date}
+      end
+
+      def parse_date(date_string)
+        return nil unless date_string
+        year = date_string.to_i
+        if is_fixed_year?(year)
+          year
+        else
+          Time.now.year + year
+        end
+      end
+
+      def is_fixed_year?(int)
+        int.abs >= 1000
+      end
     end
   end
 end

--- a/lib/smartdown/model/element/question/date.rb
+++ b/lib/smartdown/model/element/question/date.rb
@@ -4,7 +4,7 @@ module Smartdown
   module Model
     module Element
       module Question
-        class Date < Struct.new(:name, :alias)
+        class Date < Struct.new(:name, :from, :to, :alias)
           def answer_type
             Smartdown::Model::Answer::Date
           end

--- a/lib/smartdown/parser/node_transform.rb
+++ b/lib/smartdown/parser/node_transform.rb
@@ -102,9 +102,12 @@ module Smartdown
       }
 
       rule(:date => {identifier: simple(:identifier), :option_pairs => subtree(:option_pairs)}) {
+        transformed_option_pairs = Smartdown::Parser::OptionPairs.transform(option_pairs)
         Smartdown::Model::Element::Question::Date.new(
           identifier.to_s,
-          Smartdown::Parser::OptionPairs.transform(option_pairs).fetch('alias', nil)
+          transformed_option_pairs.fetch('from', nil),
+          transformed_option_pairs.fetch('to', nil),
+          transformed_option_pairs.fetch('alias', nil),
         )
       }
 

--- a/smartdown.gemspec
+++ b/smartdown.gemspec
@@ -22,4 +22,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rspec", "~> 3.0.0"
   s.add_development_dependency "rake"
   s.add_development_dependency "gem_publisher"
+  s.add_development_dependency "timecop"
 end

--- a/spec/api/date_question_spec.rb
+++ b/spec/api/date_question_spec.rb
@@ -1,0 +1,71 @@
+require 'smartdown/api/date_question'
+require 'smartdown/model/element/question/date'
+
+describe Smartdown::Api::DateQuestion do
+  before do
+    Timecop.freeze(Time.local(2014))
+  end
+
+  after do
+    Timecop.return
+  end
+
+  subject(:date_question) { Smartdown::Api::DateQuestion.new(elements) }
+  let(:elements) { [ date_question_element ] }
+  let(:date_question_element) {
+    Smartdown::Model::Element::Question::Date.new(name, *args)
+  }
+  let(:aliaz) { nil }
+  let(:args) {[start_year, end_year, aliaz]}
+
+
+  context "no to/from provided" do
+    let(:name)       { 'year_of_emancipation' }
+    let(:start_year) { nil }
+    let(:end_year)   { nil }
+
+    describe "#start_year" do
+      it 'returns good default' do
+        expect(date_question.start_year).to eq(Time.now.year - 1)
+      end
+    end
+
+    describe "#end_year" do
+      it 'returns good default' do
+        expect(date_question.end_year).to eq(Time.now.year + 3)
+      end
+    end
+  end
+
+  context "with to/from provided" do
+    context "Fixed years" do
+      let(:name)       { 'year_of_incarceration_for_possession_of_alcohol' }
+      let(:start_year) { '1920' }
+      let(:end_year)   { '1933' }
+
+      describe "start_year" do
+        specify { expect(date_question.start_year).to eq(start_year.to_i) }
+      end
+
+      describe "end_year" do
+        specify { expect(date_question.end_year).to eq(end_year.to_i) }
+      end
+    end
+
+    context "Relative years" do
+      let(:name)       { 'year_of_incarceration_for_practicing_witchcraft' }
+      let(:start_year) { '-279' }
+      let(:end_year)   { '-63' }
+
+      describe "start_year" do
+        specify { expect(date_question.start_year).to eq(1735) }
+      end
+
+      describe "end_year" do
+        specify { expect(date_question.end_year).to eq(1951) }
+      end
+
+    end
+  end
+
+end

--- a/spec/parser/element/date_question_spec.rb
+++ b/spec/parser/element/date_question_spec.rb
@@ -27,6 +27,38 @@ describe Smartdown::Parser::Element::DateQuestion do
     end
   end
 
+  context "with question tag and a date range with years" do
+    let(:source) { "[date: date_of_birth, from: 1980, to: -2]" }
+
+    it "parses" do
+      should parse(source).as(
+        date: {
+          identifier: "date_of_birth",
+          option_pairs: [
+            {
+              key: 'from',
+              value: '1980',
+            },
+            {
+              key: 'to',
+              value: '-2',
+            }
+          ]
+
+        }
+      )
+    end
+
+    describe "transformed" do
+     let(:node_name) { "my_node" }
+     subject(:transformed) {
+       Smartdown::Parser::NodeInterpreter.new(node_name, source, parser: parser).interpret
+     }
+
+     it { should eq(Smartdown::Model::Element::Question::Date.new("date_of_birth", '1980', '-2')) }
+    end
+  end
+
   context "with question tag and an alias" do
     let(:source) { "[date: date_of_birth, alias: date_for_adoption_or_birth]" }
 
@@ -50,7 +82,7 @@ describe Smartdown::Parser::Element::DateQuestion do
         Smartdown::Parser::NodeInterpreter.new(node_name, source, parser: parser).interpret
       }
 
-      it { should eq(Smartdown::Model::Element::Question::Date.new("date_of_birth", "date_for_adoption_or_birth")) }
+      it { should eq(Smartdown::Model::Element::Question::Date.new("date_of_birth", nil, nil, "date_for_adoption_or_birth")) }
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,6 +3,7 @@ $LOAD_PATH << File.expand_path("../lib", File.dirname(__FILE__))
 require 'pathname'
 require 'parslet/rig/rspec'
 require 'support/model_builder'
+require 'timecop'
 
 RSpec.configure do |config|
   if config.files_to_run.one?


### PR DESCRIPTION
## Who created this
- @karlentwistle 
- @FriedSock 
## Agile Planner Ticket

[Date question range inconsistent with SA](https://www.agileplannerapp.com/boards/105200/cards/8703)
## How do I use this

To control the range of years selected you can supply 2 optional arguments to date questions: `from` and `to`.
These can take the form of absolute values, eg.

``` markdown
[date: baby_due_date, from: 2010, to: 2015]
```

Or relative values (from the current year), eg.

``` markdown
[date: baby_due_date, from: -4, to: 1]
```

The default values for `from` and `to` are relative years: `-1` and `3` respectively.
## How do I test this

1) Edit the Gemfile in smart-answers so that it uses a local version of smartdown based on the path. By default in the GDS VM this is /var/govuk/smartdown

```
#if ENV['SMARTDOWN_DEV']
  gem 'smartdown', :path => '../smartdown'
#else
#  gem 'smartdown', '0.8.2'
#end
```

2) Checkout this branch (date_question) in smartdown
3) Bundle!!!
4) bowl smart-answers
5) Edit one of the example smartdown_flows animal-example-multiple or animal-example-simple with a syntax error. I used question_4.txt in  animal-example-simple

```
# That's not a cat!!

[date: thing, from: 2011, to: 2040]

# Go back and do not collect $200 and get rid of bulldog

[choice: question_1, alias: type_of_feline]
* lion: Lion
* tiger: Tiger
* cat: Cat
* sphynx: Sphynx
* meowth: Meowth

* type_of_feline in {lion tiger cat} => question_2
* type_of_feline is 'meowth' => question_5
* otherwise => outcome_safe_pet
```

Now navigate to the flow and check that the year for selection changes to what you're expecting.
