### PR TITLE
Parsing for nested if statements

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,6 +292,20 @@ Text if pred1, pred2, pred3 are false
 $ENDIF
 ```
 
+It is also possible to nest if statements: like so.
+
+```markdown
+
+$IF pred1?
+
+$IF pred2?
+
+Text if both true
+
+$ENDIF
+
+$ENDIF
+```
 
 ## Interpolation
 

--- a/lib/smartdown/parser/element/conditional.rb
+++ b/lib/smartdown/parser/element/conditional.rb
@@ -10,19 +10,23 @@ module Smartdown
           str("$").absent? >> NodeParser.new.markdown_block
         }
 
-        rule(:markdown_blocks_inside_conditional) {
-          markdown_block_inside_conditional.repeat(1,1) >> (newline.repeat(1) >> markdown_block_inside_conditional).repeat
+        rule(:conditional_body_block) {
+          markdown_block_inside_conditional | conditional_clause
+        }
+
+        rule(:blocks_inside_conditional) {
+          conditional_body_block.repeat(1,1) >> (newline.repeat(1) >> conditional_body_block).repeat
         }
 
         rule(:else_clause) {
           str("$ELSE") >> optional_space >> newline.repeat(2) >>
-            (markdown_blocks_inside_conditional.as(:false_case) >> newline).maybe
+            (blocks_inside_conditional.as(:false_case) >> newline).maybe
         }
 
         rule(:elseif_clause) {
           str("$ELSEIF ") >> (Predicates.new.as(:predicate) >>
           optional_space >> newline.repeat(2) >>
-          (markdown_blocks_inside_conditional.as(:true_case) >> newline).maybe >>
+          (blocks_inside_conditional.as(:true_case) >> newline).maybe >>
           ((elseif_clause | else_clause).maybe)).as(:conditional).repeat(1,1).as(:false_case)
         }
 
@@ -31,7 +35,7 @@ module Smartdown
             str("$IF ") >>
               Predicates.new.as(:predicate) >>
               optional_space >> newline.repeat(2) >>
-              (markdown_blocks_inside_conditional.as(:true_case) >> newline).maybe >>
+              (blocks_inside_conditional.as(:true_case) >> newline).maybe >>
               (else_clause | elseif_clause).maybe >>
               str("$ENDIF") >> optional_space >> line_ending
           ).as(:conditional)

--- a/spec/parser/element/conditional_spec.rb
+++ b/spec/parser/element/conditional_spec.rb
@@ -329,5 +329,42 @@ SOURCE
 
     end
   end
+
+  context "Nested IF statement" do
+    let(:source) { <<-SOURCE
+$IF pred1?
+
+#{first_true_body}
+
+$IF pred2?
+
+#{both_true_body}
+
+$ENDIF
+
+#{first_true_body}
+
+$ENDIF
+SOURCE
+}
+    context "With a body for double true case" do
+      let(:first_true_body) { "Text if first predicates is true" }
+      let(:both_true_body) { "Text if both predicates are true" }
+      it { should parse(source).as(
+           conditional: {
+             predicate: {named_predicate: "pred1?"},
+             true_case: [
+               {p: "#{first_true_body}\n"},
+               {conditional: {
+                 predicate: {named_predicate: "pred2?"},
+                 true_case: [{p: "#{both_true_body}\n"}],
+               }},
+               {p: "#{first_true_body}\n"}
+             ]
+           }
+        )
+      }
+    end
+  end
 end
 


### PR DESCRIPTION
Fortunately the Engine already handles this, thanks to the structure of elseif statements.

Whitespace / indentation of nested statements has not yet been addressed. Should come in a later PR, this feature is primarily to allow if statements nested inside snippets.

https://www.agileplannerapp.com/boards/105200/cards/8756
