### PR TITLE
Parsing of custom markdown tags inside conditionals

### DIFF
--- a/spec/parser/element/conditional_spec.rb
+++ b/spec/parser/element/conditional_spec.rb
@@ -366,5 +366,32 @@ SOURCE
       }
     end
   end
+
+  context "with custom markdown tags inside" do
+
+    let (:source) { <<-SOURCE
+$IF pred?
+
+#{true_body.chomp}
+
+$ENDIF
+SOURCE
+}
+    let(:true_body) { <<-TAG
+$E
+Bit of content in lovely custom tag
+$E
+TAG
+}
+
+    it { should parse(source).as(
+         conditional: {
+           predicate: {named_predicate: "pred?"},
+            true_case: [
+              {p: "#{true_body}"}
+           ]},
+        )
+      }
+  end
 end
 


### PR DESCRIPTION
At the moment, we need to manually exclude all of our keywords from markdown blocks because they 
begin with `$` (the same as govspeak) - we may want to choose a different character to prefix smartdown constructs with.

https://www.agileplannerapp.com/boards/105200/cards/8760
