### PR TITLE
[DEFINITELY DO NOT MERGE] Handling whitespace

### DIFF
--- a/lib/smartdown/api/node.rb
+++ b/lib/smartdown/api/node.rb
@@ -54,7 +54,7 @@ module Smartdown
           markdown_element?(element)
         end
         govspeak = markdown_elements.map(&:content).join("\n")
-        GovspeakPresenter.new(govspeak).html unless govspeak.empty?
+        Govspeak::Document.new(govspeak).to_html.html_safe
       end
     end
   end

--- a/lib/smartdown/api/outcome.rb
+++ b/lib/smartdown/api/outcome.rb
@@ -4,7 +4,7 @@ module Smartdown
 
       def next_steps
         next_step_element = elements.find{|element| element.is_a? Smartdown::Model::Element::NextSteps}
-        GovspeakPresenter.new(next_step_element.content).html if next_step_element
+        Govspeak::Document.new(next_step_element.content).to_html.html_safe if next_step_element
       end
 
     end

--- a/lib/smartdown/api/question.rb
+++ b/lib/smartdown/api/question.rb
@@ -52,7 +52,7 @@ module Smartdown
           markdown_element?(element)
         end
         govspeak = markdown_elements.map(&:content).join("\n")
-        GovspeakPresenter.new(govspeak).html unless govspeak.empty?
+        Govspeak::Document.new(govspeak).to_html.html_safe unless govspeak.empty?
       end
     end
   end

--- a/lib/smartdown/parser/base.rb
+++ b/lib/smartdown/parser/base.rb
@@ -4,10 +4,11 @@ module Smartdown
   module Parser
     class Base < Parslet::Parser
       rule(:eof) { any.absent? }
-      rule(:ws_char) { match('\s') }
+      rule(:ws_char) { space_char | str("\t") }
       rule(:space_char) { str(" ") }
       rule(:non_ws_char) { match('\S') }
-      rule(:newline) { str("\r\n") | str("\n\r") | str("\n") | str("\r") }
+      rule(:carriage_return) { str("\r\n") | str("\n\r") | str("\n") | str("\r") }
+      rule(:newline) { optional_space >> carriage_return }
       rule(:line_ending) { eof | newline }
 
       rule(:optional_space) { space_char.repeat }

--- a/lib/smartdown/parser/base.rb
+++ b/lib/smartdown/parser/base.rb
@@ -7,7 +7,7 @@ module Smartdown
       rule(:ws_char) { space_char | str("\t") }
       rule(:space_char) { str(" ") }
       rule(:non_ws_char) { match('\S') }
-      rule(:carriage_return) { str("\r\n") | str("\n\r") | str("\n") | str("\r") }
+      rule(:carriage_return) { str("\n") | str("\r") }
       rule(:newline) { ws >> carriage_return }
       rule(:line_ending) { eof | newline }
 

--- a/lib/smartdown/parser/base.rb
+++ b/lib/smartdown/parser/base.rb
@@ -8,7 +8,7 @@ module Smartdown
       rule(:space_char) { str(" ") }
       rule(:non_ws_char) { match('\S') }
       rule(:carriage_return) { str("\r\n") | str("\n\r") | str("\n") | str("\r") }
-      rule(:newline) { optional_space >> carriage_return }
+      rule(:newline) { ws >> carriage_return }
       rule(:line_ending) { eof | newline }
 
       rule(:optional_space) { space_char.repeat }

--- a/lib/smartdown/parser/node_parser.rb
+++ b/lib/smartdown/parser/node_parser.rb
@@ -36,12 +36,8 @@ module Smartdown
       # .repeat calls will not merge as subtrees where as .maybe will. This was the source of many hours
       # of head scratching, so this comment should stay here until the parselet docs (or behavior) are updated.
       rule(:markdown_blocks) {
-        markdown_block.repeat(1, 1) >> (newline.repeat(1,1) >> blanklines.as(:blanklines).repeat(0,1) >> (markdown_block)).repeat
+        markdown_block.repeat(1, 1) >> (newline.repeat(1,1) >> blanklines.as(:blanklines).repeat(0,1) >> (markdown_block)).as(:block).repeat
       }
-
-      "# Lovely title\n\nline of content\n\n\nanotherlineofcontent"
- #     ("# Lovely title\n": markdown_block, MarkdownHeading) >> (newline >> nil >> ("line of content\n": markdown_block, MarkdownParagraph))
-
 
       rule(:body) {
         markdown_blocks.as(:body) >> newline.repeat

--- a/lib/smartdown/parser/node_parser.rb
+++ b/lib/smartdown/parser/node_parser.rb
@@ -30,11 +30,15 @@ module Smartdown
       }
 
       rule(:markdown_blocks) {
-        markdown_block.repeat(1, 1) >> (newline.repeat(1) >> markdown_block).repeat
+        markdown_block.repeat(1, 1) >> (newline.repeat(1,1) >> blanklines.as(:blanklines).repeat(1,1).maybe >> (markdown_block)).repeat
       }
 
       rule(:body) {
         markdown_blocks.as(:body) >> newline.repeat
+      }
+
+      rule(:blanklines) {
+        newline.repeat(1)
       }
 
       rule(:flow) {

--- a/lib/smartdown/parser/node_parser.rb
+++ b/lib/smartdown/parser/node_parser.rb
@@ -29,9 +29,19 @@ module Smartdown
         Element::MarkdownParagraph.new
       }
 
+      # The .repeat(0,1) may look strange because the parselet website says that is the same as .maybe
+      #
+      #                           !!! .repeat(0,1) is NOT the same as .maybe !!!
+      #
+      # .repeat calls will not merge as subtrees where as .maybe will. This was the source of many hours
+      # of head scratching, so this comment should stay here until the parselet docs (or behavior) are updated.
       rule(:markdown_blocks) {
-        markdown_block.repeat(1, 1) >> (newline.repeat(1,1) >> blanklines.as(:blanklines).repeat(1,1).maybe >> (markdown_block)).repeat
+        markdown_block.repeat(1, 1) >> (newline.repeat(1,1) >> blanklines.as(:blanklines).repeat(0,1) >> (markdown_block)).repeat
       }
+
+      "# Lovely title\n\nline of content\n\n\nanotherlineofcontent"
+ #     ("# Lovely title\n": markdown_block, MarkdownHeading) >> (newline >> nil >> ("line of content\n": markdown_block, MarkdownParagraph))
+
 
       rule(:body) {
         markdown_blocks.as(:body) >> newline.repeat

--- a/lib/smartdown/parser/node_transform.rb
+++ b/lib/smartdown/parser/node_transform.rb
@@ -210,6 +210,10 @@ module Smartdown
       rule(:next_node_rules => subtree(:rules)) {
         Smartdown::Model::NextNodeRules.new(rules)
       }
+
+      rule(blanklines: simple(:content)) {
+        Smartdown::Model::Element::MarkdownParagraph.new(content)
+      }
     end
   end
 end

--- a/smartdown.gemspec
+++ b/smartdown.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
   s.license       = 'MIT'
   s.add_runtime_dependency 'parslet', '~> 1.6.1'
+  s.add_runtime_dependency 'govspeak', '~> 1.6.2'
   s.add_development_dependency "rspec", "~> 3.0.0"
   s.add_development_dependency "rake"
   s.add_development_dependency "gem_publisher"

--- a/spec/parser/base_spec.rb
+++ b/spec/parser/base_spec.rb
@@ -6,9 +6,9 @@ describe Smartdown::Parser::Base do
 
   describe "#ws" do
     subject { parser.ws }
-    it { should parse("\n") }
     it { should parse(" ") }
     it { should parse("   ") }
+    it { should parse("  ") }
   end
 
   describe "#eof" do

--- a/spec/parser/base_spec.rb
+++ b/spec/parser/base_spec.rb
@@ -23,8 +23,6 @@ describe Smartdown::Parser::Base do
 
     # Only one newline
     it { should parse("\r") }
-    it { should parse("\r\n") }
-    it { should parse("\n\r") }
     it { should parse("\n") }
 
     # Not multiple

--- a/spec/parser/node_parser_spec.rb
+++ b/spec/parser/node_parser_spec.rb
@@ -213,4 +213,50 @@ SOURCE
       })
     end
   end
+
+  context "multiple blank lines" do
+
+    let(:source) {
+<<SOURCE
+# Lovely title
+  
+
+
+
+line of content
+SOURCE
+}
+
+    it "appends surplus whitespace to the next paragraph" do
+      should parse(source).as({
+        body: [
+          { h1: "Lovely title" },
+          { blanklines: "\n\n\n" },
+          { p: "line of content\n"},
+        ]
+      })
+    end
+
+    describe "transformed" do
+      let(:node_name) { "my_node" }
+      subject(:transformed) {
+        Smartdown::Parser::NodeInterpreter.new(node_name, source, parser: parser).interpret
+      }
+
+      let(:expected_elements) {
+        [
+          Smartdown::Model::Element::MarkdownHeading.new("Lovely title"),
+          Smartdown::Model::Element::MarkdownParagraph.new("\n\n\n"),
+          Smartdown::Model::Element::MarkdownParagraph.new("line of content\n"),
+        ]
+      }
+
+      let(:expected_node_model) {
+        Smartdown::Model::Node.new(node_name, expected_elements)
+      }
+
+      it { should eq(expected_node_model) }
+    end
+  end
+
 end

--- a/spec/parser/node_parser_spec.rb
+++ b/spec/parser/node_parser_spec.rb
@@ -194,4 +194,23 @@ SOURCE
     }
   end
 
+  context "blank line with a tab on it" do
+
+    let(:source) {
+<<SOURCE
+# Lovely title
+  
+line of content
+SOURCE
+}
+
+    it "doesn't blow up" do
+      should parse(source).as({
+        body: [
+          { h1: "Lovely title" },
+          { p: "line of content\n" },
+        ]
+      })
+    end
+  end
 end

--- a/spec/parser/node_parser_spec.rb
+++ b/spec/parser/node_parser_spec.rb
@@ -259,7 +259,7 @@ SOURCE
     end
   end
 
-  context "multiple blank lines with 2 paragraphs" do
+  context "at least 3 elements (with blanklines)" do
 
     let(:source) {
 <<SOURCE
@@ -273,14 +273,16 @@ SOURCE
 }
 
     it "works" do
-      should parse(source).as({
+      #should parse(source).as({
+      weird_hash = {
         body: [
           { h1: "Lovely title" },
           { p: "line of content\n"},
           { blanklines: "\n" },
           { p: "another line of content\n"},
-        ]
-      })
+        ] }
+       require 'pry'; binding.pry
+     # })
     end
 	end
 end

--- a/spec/parser/node_parser_spec.rb
+++ b/spec/parser/node_parser_spec.rb
@@ -199,7 +199,7 @@ SOURCE
     let(:source) {
 <<SOURCE
 # Lovely title
-  
+	
 line of content
 SOURCE
 }
@@ -219,7 +219,7 @@ SOURCE
     let(:source) {
 <<SOURCE
 # Lovely title
-  
+	
 
 
 
@@ -259,4 +259,28 @@ SOURCE
     end
   end
 
+  context "multiple blank lines with 2 paragraphs" do
+
+    let(:source) {
+<<SOURCE
+# Lovely title
+	
+line of content
+
+
+another line of content
+SOURCE
+}
+
+    it "works" do
+      should parse(source).as({
+        body: [
+          { h1: "Lovely title" },
+          { p: "line of content\n"},
+          { blanklines: "\n" },
+          { p: "another line of content\n"},
+        ]
+      })
+    end
+	end
 end


### PR DESCRIPTION
This PR is to show the problems / possible solutions to Example 2 on the Handling Whitespace ticket.

https://www.agileplannerapp.com/boards/105200/cards/8759

It would be simple to just ignore multiple blanklines - but then that isn't really a problem for the parser to break if they have no semantics that effect the style of the question/outcome. If we did want to catch blanklines - and allow them to be used for styling then there are some problems with the implementation:

```
"# Lovely title\n\n\nline of content\n\n\nanotherlineofcontent"
```

This line is an example of how we would like to be able to write some smartdown - we have multiple blank lines separating our markdown paragraphs that will be actually be recognised.

it is completely possible to parse the above line like this:

```
{:body=>[
          {:h1=>"Lovely title"@2},
          {:blanklines=>"\n"@16},
          {:p=>"line of content\n"@17},
          {:blanklines=>"\n"@34},
          {:p=>"anotherlineofcontent"@35}
        ]
}
```

the blanklines nodes could then be converted to markdown paragraphs
themselves, just like paragraphs.

However, there appears to be a bug in parselet. After defining a
grammar to do this, the following line:

```
"# Lovely title\n\nline of content\n\n\nanotherlineofcontent"
```

will parse incorrectly as:

```
{:body=>[
        {:h1=>"Lovely title"@2},
        {:p=>"line of content\n"@16}
        ]
}
```

What appears to be happening is: Because there are no blanklines to be matched between the first 2 lines, when ever any blank lines (or anything else in the grouped match) are matched subsequently: the labelling is being swallowed somehow, because parsing didn't fail, the AST being returned is just wrong.

However, there is a weird possible fix without delving deep into parselet and then hoping a PR gets merged. We can add intermediate labelling that doesn't get swallowed, so we will get an AST like this:

```
{:body=>[
        {:h1=>"Lovely title"@2},
        {:block=>{:p=>"line of content\n"@16}},
        {:block=>[
                  {:blanklines=>"\n"@33},
                  {:p=>"anotherlineofcontent"@34}
                  ]
        }
        ]
}
```

So we could have `block` nodes in our AST that will contain an element, an an optional set of blanklines. We could then just flatten this in the Transformer.
