### PR TITLE
Remove html_safe from smartdown

### DIFF
--- a/lib/smartdown/api/node.rb
+++ b/lib/smartdown/api/node.rb
@@ -50,11 +50,7 @@ module Smartdown
       end
 
       def build_govspeak(elements)
-        markdown_elements = elements.select do |element|
-          markdown_element?(element)
-        end
-        govspeak = markdown_elements.map(&:content).join("\n")
-        Govspeak::Document.new(govspeak).to_html.html_safe
+        elements.select { |element| markdown_element?(element) }.map(&:content).join("\n")
       end
     end
   end

--- a/lib/smartdown/api/outcome.rb
+++ b/lib/smartdown/api/outcome.rb
@@ -3,8 +3,7 @@ module Smartdown
     class Outcome < Node
 
       def next_steps
-        next_step_element = elements.find{|element| element.is_a? Smartdown::Model::Element::NextSteps}
-        Govspeak::Document.new(next_step_element.content).to_html.html_safe if next_step_element
+        elements.find{|element| element.is_a? Smartdown::Model::Element::NextSteps}.content
       end
 
     end

--- a/lib/smartdown/api/question.rb
+++ b/lib/smartdown/api/question.rb
@@ -48,11 +48,7 @@ module Smartdown
       end
 
       def build_govspeak(elements)
-        markdown_elements = elements.select do |element|
-          markdown_element?(element)
-        end
-        govspeak = markdown_elements.map(&:content).join("\n")
-        Govspeak::Document.new(govspeak).to_html.html_safe unless govspeak.empty?
+        elements.select { |element| markdown_element?(element) }.markdown_elements.map(&:content).join("\n")
       end
     end
   end

--- a/smartdown.gemspec
+++ b/smartdown.gemspec
@@ -19,7 +19,6 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
   s.license       = 'MIT'
   s.add_runtime_dependency 'parslet', '~> 1.6.1'
-  s.add_runtime_dependency 'govspeak', '~> 3.2.0'
   s.add_development_dependency "rspec", "~> 3.0.0"
   s.add_development_dependency "rake"
   s.add_development_dependency "gem_publisher"


### PR DESCRIPTION
You will no longer need to be using active support
to use smartdown. If you are, then it is your own
responsibility to call html_safe on the html returned
but smartdown.

https://www.agileplannerapp.com/boards/105200/cards/8819
