### PR TITLE
Snippet Organisation

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,6 +342,23 @@ extension, eg `my-flow-name/snippets/my_snippet.txt`.
 
 The contents of `my_snippet` will be inserted into the outcome/question.
 
+###Snippet Organisation
+
+You can organise related snippets into a sub-directory of arbitrary depth
+
+For example:
+
+```
+## My header
+
+Markdown copy..
+
+{{snippet: my_sub_directory/my_snippet}}
+
+More copy...
+```
+Where `snippet_name` is in a `snippets/` directory in the flow root with a `.txt` extension, eg `my-flow-name/snippets/my_sub_directory/my_snippet.txt`.
+
 ## Scenarios
 
 Scenarios are meant to be run as test to check that a Smartdown flow behaves

--- a/spec/fixtures/directory_input/snippets/nested/nested_again/nsn1.txt
+++ b/spec/fixtures/directory_input/snippets/nested/nested_again/nsn1.txt
@@ -1,0 +1,1 @@
+nested snippet

--- a/spec/parser/directory_input_spec.rb
+++ b/spec/parser/directory_input_spec.rb
@@ -49,10 +49,16 @@ describe Smartdown::Parser::DirectoryInput do
   end
 
   describe "#snippets" do
-    it "returns an InputFile for every file in the snippets folder" do
-      expect(input.snippets).to match([instance_of(Smartdown::Parser::InputFile)])
-      expect(input.snippets.first.name).to eq("sn1")
-      expect(input.snippets.first.read).to eq("snippet one\n")
+    it "returns an InputFile for every file, ending in .txt, in the snippets folder to arbitrary sub directory depth" do
+      expect(input.snippets).to match([
+        instance_of(Smartdown::Parser::InputFile),
+        instance_of(Smartdown::Parser::InputFile),
+      ])
+      expect(input.snippets.map(&:name)).to include("sn1")
+      expect(input.snippets.map(&:read)).to include("snippet one\n")
+
+      expect(input.snippets.map(&:name)).to include("nested/nested_again/nsn1")
+      expect(input.snippets.map(&:read)).to include("nested snippet\n")
     end
   end
 end


### PR DESCRIPTION
## Snippet Organisation

Allow sub-directories within snippets with arbitrary depth.

For example:

```
## My header

Markdown copy..

{{snippet: my_sub_directory/my_snippet}}

More copy...
```

Where `snippet_name` is in a `snippets/` directory in the flow root with a `.txt` extension, eg `my-flow-name/snippets/my_sub_directory/my_snippet.txt`.

**Considerations**
- DirectoryInput  Doesn't allow directory traversal
- Easily extensible to any future DirectoryInput type like outcomes
