### PR TITLE
[MERGE FIRST]Fix to the public api for missing elements

### DIFF
--- a/lib/smartdown/api/outcome.rb
+++ b/lib/smartdown/api/outcome.rb
@@ -3,7 +3,8 @@ module Smartdown
     class Outcome < Node
 
       def next_steps
-        elements.find{|element| element.is_a? Smartdown::Model::Element::NextSteps}.content
+        next_steps = elements.find{ |element| element.is_a? Smartdown::Model::Element::NextSteps}
+        next_steps.content if next_steps && !next_steps.content.empty?
       end
 
     end

--- a/lib/smartdown/api/question.rb
+++ b/lib/smartdown/api/question.rb
@@ -48,7 +48,8 @@ module Smartdown
       end
 
       def build_govspeak(elements)
-        elements.select { |element| markdown_element?(element) }.markdown_elements.map(&:content).join("\n")
+        markdown_elements = elements.select { |element| markdown_element?(element) }
+        markdown_elements.map(&:content).join("\n") unless markdown_elements.empty?
       end
     end
   end


### PR DESCRIPTION
If an outcome or question was missing an element
we were blowing up, when it is actually legal to
have them missing. Now return nil instead.
(This was the behaviour before 0.11.0)
