### PR TITLE
Redirect to outcome when extra URL parameters entered after outcome 

### DIFF
--- a/lib/smartdown/api/flow.rb
+++ b/lib/smartdown/api/flow.rb
@@ -84,9 +84,9 @@ module Smartdown
     private
 
       def transform_node(node)
-        if node.elements.any?{|element| element.is_a? Smartdown::Model::Element::StartButton}
+        if node.is_start_page_node?
           Smartdown::Api::Coversheet.new(node)
-        elsif node.elements.any?{|element| element.is_a? Smartdown::Model::NextNodeRules}
+        elsif node.is_question_node?
           if node.elements.any?{|element| element.class.to_s.include?("Smartdown::Model::Element::Question")}
             Smartdown::Api::QuestionPage.new(node)
           else

--- a/lib/smartdown/engine.rb
+++ b/lib/smartdown/engine.rb
@@ -24,28 +24,26 @@ module Smartdown
       {}.merge(@initial_state)
     end
 
-    def process(raw_responses, test_start_state = nil)
-      #TODO: change interface to match started, raw_responses like API state...no need for shifting etc...
-      state = test_start_state || build_start_state
-      unprocessed_responses = raw_responses
+    def process(unprocessed_responses, test_start_state = nil)
+      state = test_start_state || build_start_state   
+
       while !unprocessed_responses.empty? do
         current_node = flow.node(state.get(:current_node))
-
         if current_node.is_start_page_node?
           # If it's a start page node, we've got to do something different because of the preceeding 'y' answer
-          transition = Transition.new(state, current_node, unprocessed_responses.shift(1))
+          answers = unprocessed_responses.shift(1)
         else
           answers = current_node.questions.map do |question|
             question.answer_type.new(unprocessed_responses.shift, question)
           end
-
-          unless answers.all?(&:valid?)
+          if answers.any?(&:invalid?)
             state = state.put(:current_answers, answers)
             break
           end
-          transition = Transition.new(state, current_node, answers)
         end
-        state = transition.next_state
+        
+        transition = Transition.new(state, current_node, answers)
+        state = transition.next_state 
       end
       state
     end

--- a/lib/smartdown/engine.rb
+++ b/lib/smartdown/engine.rb
@@ -29,6 +29,8 @@ module Smartdown
 
       while !unprocessed_responses.empty? do
         current_node = flow.node(state.get(:current_node))
+        break if current_node.is_outcome_page_node?
+        
         if current_node.is_start_page_node?
           # If it's a start page node, we've got to do something different because of the preceeding 'y' answer
           answers = unprocessed_responses.shift(1)

--- a/lib/smartdown/engine/interpolator.rb
+++ b/lib/smartdown/engine/interpolator.rb
@@ -1,3 +1,7 @@
+require 'parslet'
+require 'smartdown/parser/node_transform'
+require 'smartdown/parser/predicates'
+
 module Smartdown
   class Engine
     class Interpolator

--- a/lib/smartdown/model/answer/base.rb
+++ b/lib/smartdown/model/answer/base.rb
@@ -43,6 +43,10 @@ module Smartdown
           @error.nil?
         end
 
+        def invalid?
+          !valid?
+        end
+
       private
         def parse_other_object(comparison_object)
           if comparison_object.is_a? Base

--- a/lib/smartdown/model/node.rb
+++ b/lib/smartdown/model/node.rb
@@ -37,6 +37,14 @@ module Smartdown
         @is_start_page_node ||= !!start_button
       end
 
+      def is_question_node?
+        @is_question_node ||= elements.any?{|element| element.is_a? Smartdown::Model::NextNodeRules}
+      end
+
+      def is_outcome_page_node?
+        @is_outcome_page_node ||= !is_start_page_node? && !is_question_node?
+      end
+
       private
 
       def markdown_blocks_before_question

--- a/spec/engine_spec.rb
+++ b/spec/engine_spec.rb
@@ -186,6 +186,13 @@ describe Smartdown::Engine do
         it "recorded input is accessiable via question alias" do
           expect(subject.get("passport_type?")).to eq("greek")
         end
+
+        context "extra answers passed" do
+          let(:responses) { %w{yes greek I wanna be the very best like no one ever was} }
+          it "return current_node as outcome and ignores extra responses" do
+            expect(subject.get(:current_node)).to eq("outcome_no_visa_needed")
+          end
+        end
       end
 
       context "USA passport" do


### PR DESCRIPTION
### What does it do?

Broken

Example: 

https://www.gov.uk/pay-leave-for-parents/y/no/2015-6-9/self-employed/yes/no is an outcome
https://www.gov.uk/pay-leave-for-parents/y/no/2015-6-9/self-employed/yes/no/whatever throws an exception

Fix:

URLs with extra parameters such as:
- https://www.gov.uk/pay-leave-for-parents/y/no/2015-6-9/self-employed/yes/no/whatever
- https://www.gov.uk/pay-leave-for-parents/y/no/2015-6-9/self-employed/yes/no/whatever/other/things

now all redirect to
https://www.gov.uk/pay-leave-for-parents/y/no/2015-6-9/self-employed/yes/no (outcome page)
