### PR TITLE
Remove monkey patch on node transformer.

### DIFF
--- a/lib/smartdown/parser/node_interpreter.rb
+++ b/lib/smartdown/parser/node_interpreter.rb
@@ -7,20 +7,21 @@ require 'smartdown/parser/node_transform'
 module Smartdown
   module Parser
     class NodeInterpreter
-      attr_reader :name, :source, :reporter
+      attr_reader :name, :source, :reporter, :data_module
 
       def initialize(name, source, options = {})
         @name = name
         @source = source
-        data_module = options.fetch(:data_module, {})
+        @data_module = options.fetch(:data_module, {})
         @parser = options.fetch(:parser, Smartdown::Parser::NodeParser.new)
-        @transform = options.fetch(:transform, Smartdown::Parser::NodeTransform.new(data_module))
+        @transform = options.fetch(:transform, Smartdown::Parser::NodeTransform.new)
         @reporter = options.fetch(:reporter, Parslet::ErrorReporter::Deepest.new)
       end
 
       def interpret
         transform.apply(parser.parse(source, reporter: reporter),
-          node_name: name
+          node_name: name,
+          data_module: data_module,
         )
       end
 


### PR DESCRIPTION
And we were already passing in node_name as context
to the transform apply, doh!

https://github.com/kschiess/parslet/pull/119
