### PR TITLE
Bump to version 0.13.0 - Adds Money question type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.xx.x
+## 0.13.0
 
 * money question
 

--- a/lib/smartdown/version.rb
+++ b/lib/smartdown/version.rb
@@ -1,3 +1,3 @@
 module Smartdown
-  VERSION = "0.12.1"
+  VERSION = "0.13.0"
 end


### PR DESCRIPTION
Money question introduced in https://github.com/alphagov/smartdown/pull/131

Called like: `[money: court_fee]`

Expands on the previously existing Money answer type, which was used as a return from some SPL plugins.
