### PR TITLE
Don't insert extra line-breaks, breaking govspeak

### DIFF
--- a/lib/smartdown/api/node.rb
+++ b/lib/smartdown/api/node.rb
@@ -60,7 +60,7 @@ module Smartdown
       def build_govspeak(elements)
         elements.select { |element| markdown_element?(element) }
         return nil if elements.empty?
-        elements.map(&:content).join("\n")
+        elements.map(&:content).join("")
       end
     end
   end

--- a/lib/smartdown/api/question.rb
+++ b/lib/smartdown/api/question.rb
@@ -50,7 +50,7 @@ module Smartdown
 
       def build_govspeak(elements)
         markdown_elements = elements.select { |element| markdown_element?(element) }
-        markdown_elements.map(&:content).join("\n") unless markdown_elements.empty?
+        markdown_elements.map(&:content).join("") unless markdown_elements.empty?
       end
     end
   end

--- a/spec/acceptance/parsing_spec.rb
+++ b/spec/acceptance/parsing_spec.rb
@@ -61,6 +61,13 @@ of text.
 
 
 And handles multiple new lines
+
+And handles tables
+
+Academic Year | Form
+- | -
+2015 to 2016 | [PR1 - form (PDF, 569KB)](http://www.sfengland.slc.co.uk/media/860450/sfe_pr1_form_1516_d.pdf)
+2015 to 2016 | [PR1 - guidance notes (PDF, 199KB)](http://www.sfengland.slc.co.uk/media/860454/sfe_pr1_notes_1516_d.pdf)
 EXPECTED
       end
     end

--- a/spec/api/node_spec.rb
+++ b/spec/api/node_spec.rb
@@ -43,23 +43,35 @@ describe Smartdown::Api::Node do
   let(:question_heading) { Smartdown::Model::Element::MarkdownHeading.new(question_heading_content) }
 
   let(:body_content) { "I <3 bodyshopping" }
-  let(:body_element) {
-    Smartdown::Model::Element::MarkdownLine.new(body_content)
+  let(:body_elements) {
+    Smartdown::Model::Elements.new(
+      [
+        Smartdown::Model::Element::MarkdownLine.new(body_content),
+        Smartdown::Model::Element::MarkdownLine.new("\n")
+      ]
+    )
   }
 
   let(:post_body_content) { "hur hur such content" }
-  let(:post_body_element) {
-    Smartdown::Model::Element::MarkdownLine.new(post_body_content)
+  let(:post_body_elements) {
+    Smartdown::Model::Elements.new(
+      [Smartdown::Model::Element::MarkdownLine.new(post_body_content)]
+    )
   }
 
   let(:other_post_body_content) { "Postman Pat and his black and white cat" }
-  let(:other_post_body_element) {
-    Smartdown::Model::Element::MarkdownLine.new(other_post_body_content)
+  let(:other_post_body_elements) {
+    Smartdown::Model::Elements.new(
+      [
+        Smartdown::Model::Element::MarkdownLine.new("\n"),
+        Smartdown::Model::Element::MarkdownLine.new(other_post_body_content)
+      ]
+    )
   }
 
 
   context "with a body and post_body (and next node rules)" do
-    let(:elements) { [node_heading, body_element, question_heading, question_element, post_body_element, other_post_body_element, next_node_rules] }
+    let(:elements) { [node_heading, body_elements, question_heading, question_element, post_body_elements, other_post_body_elements, next_node_rules] }
 
     describe "#body" do
       it 'returns the content before the question element' do
@@ -77,7 +89,7 @@ describe Smartdown::Api::Node do
   end
 
   context "missing a body" do
-    let(:elements) { [question_element, post_body_element] }
+    let(:elements) { [question_element, post_body_elements] }
 
     describe "#body" do
       it 'returns nil' do
@@ -93,7 +105,7 @@ describe Smartdown::Api::Node do
   end
 
   context "missing a post body" do
-    let(:elements) { [node_heading, body_element, question_heading, question_element] }
+    let(:elements) { [node_heading, body_elements, question_heading, question_element] }
 
     describe "#body" do
       it 'returns the content before the question element' do

--- a/spec/fixtures/acceptance/cover-sheet/cover-sheet.txt
+++ b/spec/fixtures/acceptance/cover-sheet/cover-sheet.txt
@@ -17,3 +17,10 @@ of text.
 
 
 And handles multiple new lines
+
+And handles tables
+
+Academic Year | Form
+- | -
+2015 to 2016 | [PR1 - form (PDF, 569KB)](http://www.sfengland.slc.co.uk/media/860450/sfe_pr1_form_1516_d.pdf)
+2015 to 2016 | [PR1 - guidance notes (PDF, 199KB)](http://www.sfengland.slc.co.uk/media/860454/sfe_pr1_notes_1516_d.pdf)


### PR DESCRIPTION
The handling of new/blank lines changed in https://github.com/alphagov/smartdown/pull/126

This introduced a bug where extra new lines were being inserted. Both the original
new lines captured in MarkdownBlankLine and MarkdownLine and from the new lines
used when joining Markdown Elements.

Normally additional new lines are collapsed in markdown/govspeak, but some
situations, like tables, the addition new lines will break the markdown.

Now that we capture the new line and the markdown (in Elements) we don't
need to join elements with new lines. Otheriwse an element structure like:

```
    [string, new line, string]
```

which will be joined as

```
    string + new line + new line + new line string
```

The specs for API:Node needed to be updated, as they weren't using
the new Elements object and need to mimic the actual structure of a node

I think this shows that the current Element/Elements new line model
isn't quite right, and not particuarly intuitive and probably needs
revisting at some point, but for new this prevents the bug causing
broken markdown to be generated
