### PR TITLE
Release 0.13.1, fix new line markdown bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.13.1
+
+Fix bug where additional new lines were inserted into markdown text, which
+broke some markdown features (like tables) where new lines are meaningful.
+
 ## 0.13.0
 
 * money question

--- a/lib/smartdown/version.rb
+++ b/lib/smartdown/version.rb
@@ -1,3 +1,3 @@
 module Smartdown
-  VERSION = "0.13.0"
+  VERSION = "0.13.1"
 end


### PR DESCRIPTION
Release the bugfix from https://github.com/alphagov/smartdown/pull/133
