### PR TITLE
Bump version to 0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,21 @@
+## 0.14.0
+
+* Add marker syntax
+```{{marker: this_is_a_marker}}```
+* Update Api::Node to expose markers
+```node.markers # [Model::Marker(:marker_name)]```
+* Update Scenarios to implement and expose markers
+```
+Api:
+scenario.markers # ["marker_name"]
+
+In Scenario:
+has markers: marker_name, another_marker
+or
+has marker: marker_name
+```
+
+
 ## 0.13.1
 
 Fix bug where additional new lines were inserted into markdown text, which

--- a/lib/smartdown/version.rb
+++ b/lib/smartdown/version.rb
@@ -1,3 +1,3 @@
 module Smartdown
-  VERSION = "0.13.1"
+  VERSION = "0.14.0"
 end


### PR DESCRIPTION
Bump version to 0.14.0
- Add marker syntax
  `{{marker: this_is_a_marker}}`
- Update Api::Node to expose markers
  `node.markers # [Model::Marker(:marker_name)]`
- Update Scenarios to implement and expose markers

```
Api:
scenario.markers # ["marker_name"]

In Scenario:
has markers: marker_name, another_marker
or
has marker: marker_name
```
