### PR TITLE
Bump version to 0.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+## 0.15.0
+
+* Update Scenarios to implement and expose exact markers
+```
+Api:
+scenario.exact_markers # ["marker_name"]
+
+In Scenario:
+exact markers: marker_name, another_marker
+or
+exact marker: marker_name
+```
+
 ## 0.14.0
 
 * Add marker syntax

--- a/lib/smartdown/version.rb
+++ b/lib/smartdown/version.rb
@@ -1,3 +1,3 @@
 module Smartdown
-  VERSION = "0.14.0"
+  VERSION = "0.15.0"
 end


### PR DESCRIPTION
- Update Scenarios to implement and expose exact markers

```
Api:
scenario.exact_markers # ["marker_name"]

In Scenario:
exact markers: marker_name, another_marker
or
exact marker: marker_name
```
