### PR TITLE
Improve money validation regex

### DIFF
--- a/lib/smartdown/model/answer/money.rb
+++ b/lib/smartdown/model/answer/money.rb
@@ -6,7 +6,7 @@ module Smartdown
     module Answer
       class Money < Base
 
-        FORMAT_REGEX = /^£?\W*([\d|,|]+[\.]?[\d]*)$/
+        FORMAT_REGEX = /^£?\W*([\d|,|]+(\.[\d]+)?)$/
 
         def value_type
           ::Float

--- a/lib/smartdown/model/answer/salary.rb
+++ b/lib/smartdown/model/answer/salary.rb
@@ -29,7 +29,7 @@ module Smartdown
             @error = "Invalid format"
             return
           end
-          amount_per_period, @period = *matched_value[1..2]
+          amount_per_period, _, @period = *matched_value[1..3]
 
           @money_per_period = Money.new(amount_per_period)
           @amount_per_period = @money_per_period.value

--- a/spec/model/answer/money_spec.rb
+++ b/spec/model/answer/money_spec.rb
@@ -57,19 +57,43 @@ describe Smartdown::Model::Answer::Money do
     end
   end
 
-  describe "errors" do
-    context "invalid formatting" do
-      let(:money_input) {"Loads'a'money"}
+  describe "parsing" do
+    context "£200.00" do
+      let(:money_input) {"£200.00"}
 
-      it "Has errors" do
+      it "raises no errors" do
+        expect(instance.error).to eql(nil)
+      end
+    end
+
+    context "1" do
+      let(:money_input) {"1"}
+
+      it "raises no errors" do
+        expect(instance.error).to eql(nil)
+      end
+    end
+
+    context "a number that ends with a dot" do
+      let(:money_input) {"200."}
+
+      it "has errors" do
         expect(instance.error).to eql("Invalid format")
       end
     end
 
-    context "no input" do
+    context "a string with no digits" do
+      let(:money_input) {"Loads'a'money"}
+
+      it "has errors" do
+        expect(instance.error).to eql("Invalid format")
+      end
+    end
+
+    context "nil input" do
       let(:money_input) { nil }
 
-      it "Has errors" do
+      it "has errors" do
         expect(instance.error).to eql("Please answer this question")
       end
     end


### PR DESCRIPTION
A lot of users are providing values ending with a dot eg `400.` as a money value, which raises an exception when parsing the provided value with Float(), which results in a 500 response, which results in bad user experience (those users retry submitting the value tens of times in some cases according to errbit).

The regex now expects at least one digit if there is a `.` in the value.

Addresses https://github.com/alphagov/smart-answers/issues/1566
