### PR TITLE
More forgiving money input parsing

### DIFF
--- a/lib/smartdown/model/answer/money.rb
+++ b/lib/smartdown/model/answer/money.rb
@@ -35,7 +35,7 @@ module Smartdown
           else
             matched_value = value.strip.match FORMAT_REGEX
             if matched_value
-              Float matched_value[1].gsub(',','')
+              Float matched_value[1].gsub(',','').chomp('.')
             else
               @error = 'Invalid format'
               return

--- a/spec/model/answer/money_spec.rb
+++ b/spec/model/answer/money_spec.rb
@@ -20,6 +20,18 @@ describe Smartdown::Model::Answer::Money do
     specify { expect(instance.value).to eql(1523.12) }
   end
 
+  describe 'instantiate with £' do
+    let(:money_input) { '£1523.45' }
+
+    specify { expect(instance.value).to eql(1523.45) }
+  end
+
+  describe 'instantiate with float with a trailing dot' do
+    let(:money_input) { '1523.' }
+
+    specify { expect(instance.value).to eql(1523.0) }
+  end
+
   describe 'to_s' do
     it "returns value without comma delimiter" do
       expect(instance.to_s).to eql("1523.42")
@@ -49,27 +61,35 @@ describe Smartdown::Model::Answer::Money do
         expect(instance.humanize).to eql("£1,523.42")
       end
     end
+
     context "no pence" do
       let(:money_input) { '1523.00' }
       it "rounds down amounts of money correctly" do
         expect(instance.humanize).to eql("£1,523")
       end
     end
+
+    context "for value with a trailing dot" do
+      let(:money_input) { '1523.' }
+      it "ignores the trailing dot" do
+        expect(instance.humanize).to eql("£1,523")
+      end
+    end
   end
 
-  describe "errors" do
-    context "invalid formatting" do
+  describe "parsing" do
+    context "no digits" do
       let(:money_input) {"Loads'a'money"}
 
-      it "Has errors" do
+      it "raises an error" do
         expect(instance.error).to eql("Invalid format")
       end
     end
 
-    context "no input" do
+    context "empty input" do
       let(:money_input) { nil }
 
-      it "Has errors" do
+      it "raises an error" do
         expect(instance.error).to eql("Please answer this question")
       end
     end


### PR DESCRIPTION
Allows entering values with a trailing dot eg '1200.' and simply strips it.

Rationale: a lot of users do that and get a 500 response with a generic error message that does not help them improve the input.

Issue: https://github.com/alphagov/smart-answers/issues/1566

Perhaps better than https://github.com/alphagov/smartdown/pull/142
