### PR TITLE
Bump to 0.15.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.15.1
+
+Fixes a bug where a user was getting a generic 500 response when providing
+money values with a trailing dot eg `2100.`. Now it treats such values as
+money values with no decimal points, as expected by the user.
+
 ## 0.15.0
 
 * Update Scenarios to implement and expose exact markers

--- a/lib/smartdown/version.rb
+++ b/lib/smartdown/version.rb
@@ -1,3 +1,3 @@
 module Smartdown
-  VERSION = "0.15.0"
+  VERSION = "0.15.1"
 end


### PR DESCRIPTION
Fixes a bug where a user was getting a generic 500 response when providing
money values with a trailing dot eg `2100.`. Now it treats such values as
money values with no decimal points, as expected by the user.
