### PR TITLE
Fix smartdown bin script

### DIFF
--- a/bin/smartdown
+++ b/bin/smartdown
@@ -22,7 +22,7 @@ else
     engine = Smartdown::Engine.new(flow)
     end_state = engine.process(responses)
 
-    puts "RESPONSES: " + end_state.get(:responses).join(" / ")
+    puts "RESPONSES: " + end_state.get(:accepted_responses).join(" / ")
     puts "PATH: " + (end_state.get(:path) + [end_state.get(:current_node)]).join(" -> ")
     node = engine.evaluate_node(end_state)
     puts "# #{node.title}\n\n"

--- a/spec/bin/smartdown_spec.rb
+++ b/spec/bin/smartdown_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe 'bin/smartdown' do
   let(:input) { fixture("animal-example-simple") }
 
   before(:each) do
-    @output = `#{executable_path} "#{input}" #{responses} 2>&1`
+    @output = `LANG="en_GB.UTF-8" #{executable_path} "#{input}" #{responses} 2>&1`
     fail(raw_output) unless $?.success?
   end
 

--- a/spec/bin/smartdown_spec.rb
+++ b/spec/bin/smartdown_spec.rb
@@ -1,0 +1,58 @@
+require 'spec_helper'
+require 'pathname'
+
+RSpec.describe 'bin/smartdown' do
+  let(:executable_path) {
+    Pathname.new('../../bin/smartdown').expand_path(File.dirname(__FILE__))
+  }
+
+  def fixture(name)
+    File.dirname(__FILE__) + "/../fixtures/acceptance/#{name}/#{name}.txt"
+  end
+
+  let(:input) { fixture("animal-example-simple") }
+
+  before(:each) do
+    @output = `#{executable_path} "#{input}" #{responses} 2>&1`
+    fail(raw_output) unless $?.success?
+  end
+
+  describe 'invocation with no response' do
+    let(:responses) { "" }
+
+    it "prints the cover page including RESPONSES and PATH" do
+      expect(@output).to include("RESPONSES:")
+      expect(@output).to include("PATH: animal-example-simple")
+    end
+  end
+
+  describe 'invocation with single "y" response' do
+    let(:responses) { "y" }
+
+    it "prints the cover page including RESPONSES and PATH" do
+      expect(@output).to include("RESPONSES: y")
+      expect(@output).to include("PATH: animal-example-simple -> question_1")
+      expect(@output).to include("What type of feline do you have?")
+    end
+  end
+
+  describe 'invocation with single responses "y lion"' do
+    let(:responses) { "y lion" }
+
+    it "prints the cover page including RESPONSES and PATH" do
+      expect(@output).to include("RESPONSES: y / lion")
+      expect(@output).to include("PATH: animal-example-simple -> question_1 -> question_2")
+      expect(@output).to include("Are you trained for lions?")
+    end
+  end
+
+  describe 'invocation with single responses "y lion yes"' do
+    let(:responses) { "y lion yes" }
+
+    it "prints the outcome page including RESPONSES and PATH" do
+      expect(@output).to include("RESPONSES: y / lion / yes")
+      expect(@output).to include("PATH: animal-example-simple -> question_1 -> question_2 -> outcome_trained_with_lions")
+      expect(@output).to include("You'll be alright, I think.")
+    end
+  end
+end

--- a/spec/bin/smartdown_spec.rb
+++ b/spec/bin/smartdown_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
 require 'pathname'
+require 'English'
 
 RSpec.describe 'bin/smartdown' do
   let(:executable_path) {
@@ -14,7 +15,7 @@ RSpec.describe 'bin/smartdown' do
 
   before(:each) do
     @output = `LANG="en_GB.UTF-8" #{executable_path} "#{input}" #{responses} 2>&1`
-    fail(raw_output) unless $?.success?
+    fail(raw_output) unless $CHILD_STATUS.success?
   end
 
   describe 'invocation with no response' do


### PR DESCRIPTION
The `bin/smartdown` script is a utility for evaluating smartdown flows from the command line. It's  intended for use by developers when building flows, rather than being used in any production services.

It was untested and as smartdown itself evolved it had broken because there were no tests to reveal that fact.

The actual cause of the breakage was that the `responses` variable was renamed to `accepted_responses` in 1df7819.

This PR fixes the script by changing it to use the correct variable. Also added an integration test.
