### PR TITLE
Add `Smartdown::Api::Flow#content_id`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Add `Smartdown::Api::Flow#content_id`
+
 ## 0.15.1
 
 Fixes a bug where a user was getting a generic 500 response when providing

--- a/lib/smartdown/api/flow.rb
+++ b/lib/smartdown/api/flow.rb
@@ -46,6 +46,10 @@ module Smartdown
         front_matter.fetch :satisfies_need, nil
       end
 
+      def content_id
+        front_matter.fetch :content_id, nil
+      end
+
       def status
         front_matter.status
       end

--- a/spec/acceptance/flow_spec.rb
+++ b/spec/acceptance/flow_spec.rb
@@ -141,8 +141,9 @@ describe Smartdown::Api::Flow do
     it "has a need id" do
       expect(flow.need_id).to eq("100982")
     end
+
+    it "has a content id" do
+      expect(flow.content_id).to eq("A-NICE-CONTENT-ID")
+    end
   end
-
 end
-
-

--- a/spec/fixtures/acceptance/animal-example-simple/animal-example-simple.txt
+++ b/spec/fixtures/acceptance/animal-example-simple/animal-example-simple.txt
@@ -2,6 +2,7 @@
 meta_description: Animals eh?
 satisfies_need: 100982
 status: draft
+content_id: A-NICE-CONTENT-ID
 ---
 
 # A simple example of smartdown


### PR DESCRIPTION
Smartdown answers should be able to have a `content_id`. The id will be sent to the content-store and panopticon to enable tagging.

This PR is a prerequisite to update the smartanswers application.

Trello: https://trello.com/c/K87fWrYx & https://trello.com/c/ReoZKx9S
