### PR TITLE
Add deprecation message to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+# DEPRECATED
+
+This repository is no longer maintained.
+
 # Smartdown [![Build Status](https://travis-ci.org/alphagov/smartdown.svg?branch=master)](https://travis-ci.org/alphagov/smartdown)
 
 Smartdown is a [custom formatting language](http://www.martinfowler.com/bliki/DomainSpecificLanguage.html) designed to generate HTML formatted questions. These questions can then be joined in a manner that articulates a full user journey.


### PR DESCRIPTION
I copied the message from [searchtools](https://github.com/gds-attic/searchtools) which has been deprecated and moved to the GDS Attic.

We're no longer using Smartdown in the Smart Answers project (see https://github.com/alphagov/smart-answers/pull/2043) and want to highlight that we're no longer maintaining this library.
